### PR TITLE
Add 'versions' table and update schema

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,9 @@ gem 'sidekiq-scheduler', '~> 4'
 # External API's
 gem 'httparty'
 
+#Audit tables
+gem 'paper_trail'
+
 # Fulltext search
 gem 'pg_search', '~> 2.3'
 
@@ -81,6 +84,7 @@ gem 'aws-sdk-s3', require: false
 
 # dry gems
 gem 'dry-monads'
+gem 'dry-container'
 gem 'dry-validation'
 gem 'dry-auto_inject'
 gem 'reform'

--- a/app/models/user_account.rb
+++ b/app/models/user_account.rb
@@ -31,6 +31,8 @@ class UserAccount < ApplicationRecord
 
   has_secure_password
 
+  belongs_to :user_profile, optional: true
+
   delegate :first_name,
            :last_name,
            :gender,
@@ -41,9 +43,4 @@ class UserAccount < ApplicationRecord
            :city,
            :language,
            :timezone, to: :user_profile
-
-  def dl
-    UserAccount.last.destroy
-    UserProfile.last.destroy
-  end
 end

--- a/app/models/user_profiles_role.rb
+++ b/app/models/user_profiles_role.rb
@@ -13,7 +13,7 @@
 # Indexes
 #
 #  index_user_profiles_roles_on_role_id          (role_id)
-#  index_user_profiles_roles_on_user_profile_id  (user_profile_id) UNIQUE
+#  index_user_profiles_roles_on_user_profile_id  (user_profile_id)
 #
 # Foreign Keys
 #

--- a/db/migrate/20240624144825_create_versions.rb
+++ b/db/migrate/20240624144825_create_versions.rb
@@ -1,0 +1,38 @@
+# This migration creates the `versions` table, the only schema PT requires.
+# All other migrations PT provides are optional.
+class CreateVersions < ActiveRecord::Migration[7.1]
+
+  # The largest text column available in all supported RDBMS is
+  # 1024^3 - 1 bytes, roughly one gibibyte.  We specify a size
+  # so that MySQL will use `longtext` instead of `text`.  Otherwise,
+  # when serializing very large objects, `text` might not be big enough.
+  TEXT_BYTES = 1_073_741_823
+
+  def change
+    create_table :versions, id: :uuid do |t|
+      t.string   :item_type, null: false
+      t.string   :item_id,   null: false
+      t.string   :event,     null: false
+      t.string   :whodunnit
+      t.text     :object, limit: TEXT_BYTES
+
+      # Known issue in MySQL: fractional second precision
+      # -------------------------------------------------
+      #
+      # MySQL timestamp columns do not support fractional seconds unless
+      # defined with "fractional seconds precision". MySQL users should manually
+      # add fractional seconds precision to this migration, specifically, to
+      # the `created_at` column.
+      # (https://dev.mysql.com/doc/refman/5.6/en/fractional-seconds.html)
+      #
+      # MySQL users should also upgrade to at least rails 4.2, which is the first
+      # version of ActiveRecord with support for fractional seconds in MySQL.
+      # (https://github.com/rails/rails/pull/14359)
+      #
+      # MySQL users should use the following line for `created_at`
+      # t.datetime :created_at, limit: 6
+      t.datetime :created_at
+    end
+    add_index :versions, %i[item_type item_id]
+  end
+end

--- a/db/migrate/20240624144826_add_object_changes_to_versions.rb
+++ b/db/migrate/20240624144826_add_object_changes_to_versions.rb
@@ -1,0 +1,12 @@
+# This migration adds the optional `object_changes` column, in which PaperTrail
+# will store the `changes` diff for each update event. See the readme for
+# details.
+class AddObjectChangesToVersions < ActiveRecord::Migration[7.1]
+  # The largest text column available in all supported RDBMS.
+  # See `create_versions.rb` for details.
+  TEXT_BYTES = 1_073_741_823
+
+  def change
+    add_column :versions, :object_changes, :text, limit: TEXT_BYTES
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_18_015203) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_24_144826) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -62,6 +62,17 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_18_015203) do
     t.datetime "updated_at", null: false
     t.index ["role_id"], name: "index_user_profiles_roles_on_role_id"
     t.index ["user_profile_id"], name: "index_user_profiles_roles_on_user_profile_id"
+  end
+
+  create_table "versions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "item_type", null: false
+    t.string "item_id", null: false
+    t.string "event", null: false
+    t.string "whodunnit"
+    t.text "object"
+    t.datetime "created_at"
+    t.text "object_changes"
+    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
   add_foreign_key "user_accounts", "user_profiles"


### PR DESCRIPTION
A new table called 'versions' has been created for audit logs. This table is going to store history of record changes in the system. Additionally, the schema has been updated and 'paper_trail' gem has been added to the Gemfile for version management. Also, minor modifications have been done in 'user_profiles_role' and 'user_account's' models.