### PR TITLE
Add organizations endpoint with pagination and sorting

### DIFF
--- a/app/concepts/api/v1/lib/paginates/paginate.rb
+++ b/app/concepts/api/v1/lib/paginates/paginate.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Lib
+      module Paginates
+        class Paginate
+          def initialize(ctx, model)
+            @ctx = ctx
+            @model = model
+            pagy
+          end
+
+          def pagy
+            @ctx[:pagy], @ctx[:model] = Services::Pagy.call(
+              @model,
+              page: @ctx['contract.paginate'].page.number,
+              items: @ctx['contract.paginate'].page.size,
+              count: @ctx[:custom_count]
+            )
+          end
+
+          def valid_page?
+            !pagy.overflow?
+          end
+
+          def assign_paginate_errors(ctx, **)
+            @ctx['contract.default'].merge!(ctx['contract.paginate'].errors.messages)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/lib/queries/query_helper.rb
+++ b/app/concepts/api/v1/lib/queries/query_helper.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Lib
+      module Queries
+        module QueryHelper
+          def direction_with_null_position
+            "#{sort[:direction]} #{nulls_position}"
+          end
+
+          def sort_by_status_and_name(relation, table_name = nil)
+            relation = relation.order(sort.values.join(' ').to_s)
+            return relation if sort[:field] == 'name'
+            return relation.order("name #{sort[:direction]}") if table_name.nil?
+
+            relation.order("#{table_name}.name #{sort[:direction]}")
+          end
+
+          def sort_by_table_columns(relation)
+            relation.order(sort.values.join(' ').to_s)
+          end
+
+          def sort_by_table_columns_with_null_position(relation)
+            relation.order(sort.values.push(nulls_position).join(' ').to_s)
+          end
+
+          private
+
+          def nulls_position
+            position = sort[:direction] == 'desc' ? 'LAST' : 'FIRST'
+            "NULLS #{position}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/lib/services/pagy.rb
+++ b/app/concepts/api/v1/lib/services/pagy.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Lib
+      module Services
+        class Pagy
+          class << self
+            include ::Pagy::Backend
+
+            def call(collection, page:, **options)
+              # emulating controller environment for Pagy helper: https://github.com/ddnexus/pagy/blob/master/lib/pagy/backend.rb#L20
+              @params = { page: }
+              pagy(collection, options)
+            end
+
+            private
+
+            attr_reader :params
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/organizations/contracts/index.rb
+++ b/app/concepts/api/v1/organizations/contracts/index.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Organizations
+      module Contracts
+        class Index < Dry::Validation::Contract
+          def self.kall(...)
+            new.call(...)
+          end
+          params do
+            optional(:filter).maybe(:hash) do
+              optional(:name).maybe(:string)
+            end
+
+            optional(:page).maybe(:hash) do
+              optional(:is_cursor).maybe(:bool)
+            end
+
+            optional(:sort).maybe(:string)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/organizations/operations/index.rb
+++ b/app/concepts/api/v1/organizations/operations/index.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Organizations
+      module Operations
+        class Index < ApplicationOperation
+          include Dry::Transaction
+
+          tee :params
+          step :validate_schema
+          tee :cursor_and_paginate
+          step :list
+          tee :page_pagination?
+          tee :meta
+
+          def params(input)
+            @ctx = {}
+            @params = input.fetch(:params)
+            @ctx['contract.paginate'] = @params[:page]
+          end
+
+          def validate_schema
+            @ctx['contract.default'] = Api::V1::Organizations::Contracts::Index.kall(@params)
+            is_valid = @ctx['contract.default'].success?
+            return Success({ ctx: @ctx, type: :success }) if is_valid
+
+            Failure({ ctx: @ctx, type: :invalid }) unless is_valid
+          end
+
+          def cursor_and_paginate
+            @ctx[:sort] = { field: 'organizations.name', direction: 'asc' }
+          end
+
+          def list
+            @ctx[:data] = Api::V1::Organizations::Queries::Index.call(@ctx['contract.default']['filter'], @ctx[:sort])
+            Success({ ctx: @ctx, type: :success })
+          end
+
+          def page_pagination?
+            @params.dig(:page, :is_cursor)
+          end
+
+          def paginate
+            @pagy = Api::V1::Lib::Paginates::Paginate.new(@ctx, @ctx[:data])
+            Success({ ctx: @ctx, type: :success })
+          end
+
+          def meta
+            @ctx[:meta] = {
+              # total: @pagy.count,
+              has_more: @pagy.try(:has_more)
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/organizations/operations/show.rb
+++ b/app/concepts/api/v1/organizations/operations/show.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Organizations
+      module Operations
+        class Show < ApplicationOperation
+          include Dry::Transaction
+
+          tee :params
+          step :find_organization
+
+          def params(input)
+            @ctx = {}
+            @params = input.fetch(:params)
+          end
+
+          def find_organization
+            @ctx[:data] = Organization.find_by(id: @params[:id])
+            Success({ ctx: @ctx, type: :success })
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/organizations/queries/index.rb
+++ b/app/concepts/api/v1/organizations/queries/index.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Organizations
+      module Queries
+        class Index
+          include Api::V1::Lib::Queries::QueryHelper
+
+          def initialize(filter, sort)
+            @model = Organization
+            @filter = filter
+            @sort = sort
+          end
+
+          def self.call(...)
+            new(...).call
+          end
+
+          def call
+            @model.where(discarded_at: nil)
+                  .yield_self(&method(:name_clause))
+                  .yield_self(&method(:sort_clause))
+          end
+
+          private
+
+          attr_reader :organizations, :filter, :sort
+
+          def name_clause(relation)
+            return relation if @filter.nil? || @filter[:name].blank?
+
+            relation.where('organizations.name ilike :query', query: "%#{@filter[:name]}%")
+          end
+
+          def sort_clause(relation)
+            return relation if @sort.nil? || @sort.blank?
+
+            case @sort[:field]
+            when 'name', 'status' then sort_by_status_and_name(relation, :organizations)
+            when 'organizations.name' then sort_by_table_columns(relation)
+            else relation
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/organizations/serializers/index.rb
+++ b/app/concepts/api/v1/organizations/serializers/index.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Organizations
+      module Serializers
+        class Index < ApplicationSerializer
+          set_type :organization
+
+          attributes :name
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class OrganizationsController < AuthorizedApiController
+      def index
+        endpoint operation: Api::V1::Organizations::Operations::Index,
+                 renderer_options: { serializer: Api::V1::Organizations::Serializers::Index },
+                 options: { current_user: }
+      end
+
+      def show
+        endpoint operation: Api::V1::Organizations::Operations::Show,
+                 renderer_options: { serializer: Api::V1::Organizations::Serializers::Index },
+                 options: { current_user: }
+      end
+    end
+  end
+end

--- a/app/decorators/organization_decorator.rb
+++ b/app/decorators/organization_decorator.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class OrganizationDecorator < Draper::Decorator
+  delegate_all
+
+  # Define presentation-specific methods here. Helpers are accessed through
+  # `helpers` (aka `h`). You can override attributes, for example:
+  #
+  #   def created_at
+  #     helpers.content_tag :span, class: 'time' do
+  #       object.created_at.strftime("%a %m/%d/%y")
+  #     end
+  #   end
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: organizations
+#
+#  id           :bigint           not null, primary key
+#  discarded_at :datetime
+#  name         :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_organizations_on_discarded_at  (discarded_at)
+#  index_organizations_on_name          (name) UNIQUE
+#
+class Organization < ApplicationRecord
+  include Discard::Model
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  resources :organizations
   get 'up' => 'rails/health#show', as: :rails_health_check
 
   namespace :api do
@@ -13,6 +14,7 @@ Rails.application.routes.draw do
           end
         end
       end
+      resources :organizations
     end
   end
 end

--- a/db/migrate/20240626071306_create_organizations.rb
+++ b/db/migrate/20240626071306_create_organizations.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateOrganizations < ActiveRecord::Migration[7.1]
+  def change
+    create_table :organizations do |t|
+      t.string :name
+      t.datetime :discarded_at
+
+      t.timestamps
+    end
+
+    add_index :organizations, :name, unique: true
+    add_index :organizations, :discarded_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_24_144826) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_26_071306) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "organizations", force: :cascade do |t|
+    t.string "name"
+    t.datetime "discarded_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["discarded_at"], name: "index_organizations_on_discarded_at"
+    t.index ["name"], name: "index_organizations_on_name", unique: true
+  end
 
   create_table "roles", force: :cascade do |t|
     t.string "name"


### PR DESCRIPTION
This commit introduces the organizations endpoint to the API with added features for pagination and sorting. It includes the implementation of new classes and modules for managing pagination, handling queries and various test cases. It also ensures compliance with the Organization's model, serializers and decorators. Additionally, it includes the creation of the organizations table in the database.