### PR TITLE
Add NamingConvention serializer in API v1 lib

### DIFF
--- a/app/concepts/api/v1/lib/serializers/naming_convention.rb
+++ b/app/concepts/api/v1/lib/serializers/naming_convention.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Lib
+      module Serializers
+        class NamingConvention
+          attr_reader :res
+
+          def initialize(params, type = :to_camel_case)
+            case type
+            when :to_camel_case
+              @res = to_camel_case(params)
+            when :to_snake_case
+              @res = to_snake_case(params)
+            end
+          end
+
+          private
+
+          def to_snake_case(params)
+            case params
+            when Hash
+              params.transform_keys { |key| key.to_s.underscore }.transform_values do |value|
+                to_snake_case(value)
+              end
+            when Array
+              params.map { |value| to_snake_case(value) }
+            else
+              params
+            end
+          end
+
+          def to_camel_case(params)
+            params.transform_keys do |key|
+              key.to_s.camelize(:lower)
+            end.transform_values do |value|
+              value.is_a?(Hash) ? to_camel_case(value) : value
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/users/sessions/operations/create.rb
+++ b/app/concepts/api/v1/users/sessions/operations/create.rb
@@ -70,7 +70,7 @@ module Api
               result = Api::V1::Users::Lib::CreateTokens.call(@ctx, account: @ctx[:model])
 
               if result
-                @ctx[:meta] = { jwt: result }
+                @ctx[:meta] = { jwt: Api::V1::Lib::Serializers::NamingConvention.new(result, :to_camel_case) }
                 Success({ ctx: @ctx, type: :created })
               else
                 @ctx['contract.default'].errors.add(:base, I18n.t('errors.session.deactivated'))


### PR DESCRIPTION
A new NamingConvention class has been introduced in the API v1 library serializers. This class helps in converting the key/value pairs of given parameters to snake case or camel case. Additionally, NamingConvention serializer usage has been added in the create session operation to format the JWT token.