### PR TITLE
Add meta parameter to compose_render_hash

### DIFF
--- a/app/lib/services/compose_render_hash.rb
+++ b/app/lib/services/compose_render_hash.rb
@@ -20,6 +20,7 @@ module Services
       debug_response if %w[staging sandbox release].include? Rails.env
       params = {model: @model, serializer: @serializer,
                 include: @include,
+                meta: @meta,
                 pagy: @pagy,
                 expose: @expose,
                 status: @status}


### PR DESCRIPTION
A new parameter 'meta' has been added to the compose_render_hash method to expand its functionalities. This update ensures that the method can accommodate more diverse data requirements, managing them efficiently within different environments.