### PR TITLE
Refactor location contract parameters

### DIFF
--- a/app/concepts/api/v1/locations/contracts/index.rb
+++ b/app/concepts/api/v1/locations/contracts/index.rb
@@ -9,9 +9,8 @@ module Api
             new.call(...)
           end
           params do
-            required(:country_id).maybe(:integer)
-            optional(:filter).maybe(:hash) do
-              optional(:country_id).maybe(:string)
+            required(:filter).filled(:hash) do
+              required(:country_id).filled(:string)
             end
 
             optional(:page).maybe(:hash) do


### PR DESCRIPTION
The location contract's parameters have been restructured for better clarity. The 'country_id' parameter no longer stands alone and is instead nested under the 'filter' parameter, which is now required. The 'country_id' inside 'filter' is also now required and must be a string.