### PR TITLE
Fix object persistence in seeding script

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -37,12 +37,12 @@ unless SeedTask.find_by(task_name: 'states_and_cities')
 
     #create cities
     state['cities']&.each do |city|
-      city_persisted = City.create(name: city['name'], state: state_persisted,  country:)
+      city_persisted = City.create(name: city['name'], state: state_persisted, country:)
 
 
       #create neighboorhoods
       city['neighborhoods']&.each do |neighborhood|
-        Neighborhood.new(name: neighborhood['name'], state: state_persisted, country:, city:city_persisted)
+        Neighborhood.create(name: neighborhood['name'], state: state_persisted, country:, city:city_persisted)
       end
     end
   end


### PR DESCRIPTION
The changes made ensure that both city and neighborhood objects are properly persisted when running the database seeding script. Previously, cities were being created correctly, but neighborhoods were simply being instantiated without being saved in the database. This fix ensures all data is correctly saved.