### PR TITLE
Add snake_case conversion to user account creation

### DIFF
--- a/app/concepts/api/v1/users/accounts/operations/create.rb
+++ b/app/concepts/api/v1/users/accounts/operations/create.rb
@@ -9,6 +9,7 @@ module Api
             include Dry::Transaction
 
             tee :params
+            tee :to_snake_case
             step :validate_schema
             step :create_profile
             step :create_account
@@ -17,6 +18,10 @@ module Api
             def params(input)
               @ctx = {}
               @params = input.fetch(:params)
+            end
+
+            def to_snake_case
+              @params = Api::V1::Lib::Serializers::NamingConvention.new(@params, :to_snake_case).res
             end
 
             def validate_schema


### PR DESCRIPTION
A new operation 'to_snake_case' has been added to the user account creation process. This operation converts incoming parameters to snake_case using the 'NamingConvention' serializer, ensuring the parameters adhere to the general naming convention standards across the application.