### PR TITLE
Rename class in update.rb from Index to Update

### DIFF
--- a/app/concepts/api/v1/organizations/queries/update.rb
+++ b/app/concepts/api/v1/organizations/queries/update.rb
@@ -4,7 +4,7 @@ module Api
   module V1
     module Organizations
       module Queries
-        class Index
+        class Update
           include Api::V1::Lib::Queries::QueryHelper
 
           def initialize(filter, sort)


### PR DESCRIPTION
The class name in api/v1/organizations/queries/update.rb file was mistakenly named Index instead of Update. This commit corrects the class name, aligning it with the file's purpose.