### PR TITLE
Rename class Index to Update in Teams Queries

### DIFF
--- a/app/concepts/api/v1/teams/queries/update.rb
+++ b/app/concepts/api/v1/teams/queries/update.rb
@@ -4,7 +4,7 @@ module Api
   module V1
     module Teams
       module Queries
-        class Index
+        class Update
           include Api::V1::Lib::Queries::QueryHelper
 
           def initialize(filter, sort)


### PR DESCRIPTION
The commit changes the name of the class from Index to Update in Teams Queries module. This is done to correctly represent the functionality of the class, which involves updates not indexing.