### PR TITLE
Deactivate http_authenticate before_action

### DIFF
--- a/app/controllers/concerns/http_auth_concern.rb
+++ b/app/controllers/concerns/http_auth_concern.rb
@@ -6,7 +6,7 @@ module HttpAuthConcern
   included do
     include ActionController::HttpAuthentication::Basic::ControllerMethods
 
-    before_action :http_authenticate
+    #before_action :http_authenticate
   end
 
   def http_authenticate


### PR DESCRIPTION
The http_authenticate method was previously called before each action in the HTTP authentication controller. This updates the code to comment out this line, effectively deactivating the before action call to the http_authenticate method.