### PR TITLE
Refactor team-related modules and routes

### DIFF
--- a/app/concepts/api/v1/organizations/operations/update.rb
+++ b/app/concepts/api/v1/organizations/operations/update.rb
@@ -35,11 +35,12 @@ module Api
 
           def update_organization
             begin
-              @ctx[:model].update(@ctx['contract.default'].model[:organization])
+              @ctx[:model].update(@ctx['contract.default'].values.data)
               return Success({ ctx: @ctx, type: :success })
             rescue => error
-              @ctx['contract.default'].errors.add(:base, I18n.t('errors.session.deactivated'))
-              Failure({ ctx: @ctx, type: :invalid, model: true }) unless @ctx[:model]
+              add_errors(@ctx['contract.default'].errors,nil, I18n.t('errors.users.not_found'),
+                         custom_predicate: :not_found?)
+              return Failure({ ctx: @ctx, type: :invalid, model: true })
             end
           end
         end

--- a/app/concepts/api/v1/teams/contracts/create.rb
+++ b/app/concepts/api/v1/teams/contracts/create.rb
@@ -5,7 +5,6 @@ module Api
     module Teams
       module Contracts
         class Create < Dry::Validation::Contract
-
           def self.kall(...)
             new.call(...)
           end
@@ -13,11 +12,17 @@ module Api
           params do
             required(:name).filled(:string)
             required(:organization_id).filled(:integer)
-            optional(:neighborhood_id).filled(:integer)
             optional(:team_members_attributes).array(:hash) do
-              optional(:user_account_id).maybe(:integer)
+              optional(:user_account_id).filled(:integer)
             end
           end
+
+          rule(:team_members_attributes).each do
+            if value[:user_account_id] && !UserAccount.exists?(id: value[:user_account_id])
+              key.failure('user_account does not exist')
+            end
+          end
+
         end
       end
     end

--- a/app/concepts/api/v1/teams/contracts/destroy.rb
+++ b/app/concepts/api/v1/teams/contracts/destroy.rb
@@ -9,7 +9,7 @@ module Api
             new.call(...)
           end
           params do
-            required(:organization_ids).filled(:array).each(:integer)
+            required(:team_ids).filled(:array).each(:integer)
           end
         end
       end

--- a/app/concepts/api/v1/teams/contracts/update.rb
+++ b/app/concepts/api/v1/teams/contracts/update.rb
@@ -11,8 +11,20 @@ module Api
 
           params do
             required(:id).filled(:integer)
-            required(:name).filled(:string)
+            optional(:name).filled(:string)
+            optional(:organization_id).filled(:string)
+            optional(:team_members_attributes).array(:hash) do
+              optional(:user_account_id).filled(:integer)
+              optional(:_destroy).filled(:integer)
+            end
           end
+
+          rule(:team_members_attributes).each do
+            if value[:user_account_id] && TeamMember.exists?(team_id: values[:id], user_account_id: value[:user_account_id])
+              key.failure('member already exists in this team')
+            end
+          end
+
         end
       end
     end

--- a/app/concepts/api/v1/teams/queries/update.rb
+++ b/app/concepts/api/v1/teams/queries/update.rb
@@ -4,7 +4,7 @@ module Api
   module V1
     module Teams
       module Queries
-        class Index
+        class Update
           include Api::V1::Lib::Queries::QueryHelper
 
           def initialize(filter, sort)
@@ -22,7 +22,7 @@ module Api
 
           private
 
-          attr_reader :Teams, :filter, :sort
+          attr_reader :teams, :filter, :sort
 
           def name_clause(relation)
             return relation if @filter.nil? || @filter[:name].blank?

--- a/app/concepts/api/v1/teams/serializers/index.rb
+++ b/app/concepts/api/v1/teams/serializers/index.rb
@@ -9,6 +9,7 @@ module Api
 
           attributes :name
           has_many :team_members, serializer: Member
+          belongs_to :organization, serializer: Api::V1::Organizations::Serializers::Show
 
         end
       end

--- a/app/concepts/api/v1/teams/serializers/member.rb
+++ b/app/concepts/api/v1/teams/serializers/member.rb
@@ -7,7 +7,7 @@ module Api
         class Member < ApplicationSerializer
           set_type :member_team
 
-          attributes  :first_name, :last_name
+          attributes  :user_account_id, :first_name, :last_name
 
         end
       end

--- a/app/concepts/api/v1/teams/serializers/show.rb
+++ b/app/concepts/api/v1/teams/serializers/show.rb
@@ -9,6 +9,7 @@ module Api
 
           attributes :name
           has_many :team_members, serializer: Member
+          belongs_to :organization, serializer: Api::V1::Organizations::Serializers::Show
 
         end
       end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -31,6 +31,6 @@ class Team < ApplicationRecord
   belongs_to :neighborhood, optional: true
   has_many :team_members, dependent: :destroy
 
-  accepts_nested_attributes_for :team_members
+  accepts_nested_attributes_for :team_members, allow_destroy: true
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,11 @@ Rails.application.routes.draw do
             put 'change_status'
           end
         end
-        resources :teams
+        resources :teams do
+          collection do
+            delete :destroy
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
The code changes primarily involve refactoring of team-related operations - create, update and destroy. Creation and updating of team members have been enhanced with checks for existing team members and user accounts. A functionality to destroy team members has also been added. Additionally, serializer changes allow team operations to include 'organization'. The handling of update operations has been improved within a transaction block. This also involves necessary changes in routes and model settings to support these operations.