### PR TITLE
Add CRUD operations and contracts for country and city

### DIFF
--- a/app/concepts/api/v1/cities/contracts/create.rb
+++ b/app/concepts/api/v1/cities/contracts/create.rb
@@ -1,0 +1,32 @@
+module Api
+  module V1
+    module Cities
+      module Contracts
+        class Create < Dry::Validation::Contract
+          def self.kall(...)
+            new.call(...)
+          end
+
+          params do
+            required(:name).filled(:string)
+            required(:country_id).filled(:string)
+            required(:state_id).filled(:string)
+            optional(:neighborhoods_attributes).array(:hash) do
+              optional(:name).filled(:string)
+            end
+          end
+
+          rule(:neighborhoods_attributes) do
+            if value.is_a?(Array)
+              value.each do |city|
+                city[:country_id] = values[:country_id].to_s
+                city[:state_id] = values[:state_id].to_s
+
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/cities/contracts/destroy.rb
+++ b/app/concepts/api/v1/cities/contracts/destroy.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Cities
+      module Contracts
+        class Destroy < Dry::Validation::Contract
+          def self.kall(...)
+            new.call(...)
+          end
+          params do
+            required(:cities_ids).filled(:array).each(:integer)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/cities/contracts/index.rb
+++ b/app/concepts/api/v1/cities/contracts/index.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Cities
+      module Contracts
+        class Index < Dry::Validation::Contract
+          def self.kall(...)
+            new.call(...)
+          end
+          params do
+            optional(:filter).maybe(:hash) do
+              optional(:name).maybe(:string)
+            end
+
+            optional(:page).maybe(:hash) do
+              optional(:is_cursor).maybe(:bool)
+            end
+
+            optional(:sort).maybe(:string)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/cities/contracts/update.rb
+++ b/app/concepts/api/v1/cities/contracts/update.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Cities
+      module Contracts
+        class Update < Dry::Validation::Contract
+          def self.kall(...)
+            new.call(...)
+          end
+
+          params do
+            required(:id).filled(:integer)
+            optional(:name).filled(:string)
+            optional(:neighborhoods_attributes).array(:hash) do
+              optional(:id).filled(:integer)
+              optional(:_destroy).filled(:integer)
+            end
+          end
+
+          rule(:neighborhoods_attributes).each do
+            if value[:id] && Neighborhood.exists?(id: values[:id], discarded_at: nil)
+              key.failure('Neighborhood already exists in this city')
+            end
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/cities/operations/create.rb
+++ b/app/concepts/api/v1/cities/operations/create.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Cities
+      module Operations
+        class Create < ApplicationOperation
+          include Dry::Transaction
+
+          tee :params
+          step :validate_schema
+          step :create_city
+          tee :includes
+
+          def params(input)
+            @ctx = {}
+            @params = to_snake_case(input[:params])
+          end
+
+          def validate_schema
+            @ctx['contract.default'] = Api::V1::Cities::Contracts::Create.kall(@params)
+            is_valid = @ctx['contract.default'].success?
+            return Success({ ctx: @ctx, type: :success }) if is_valid
+
+            Failure({ ctx: @ctx, type: :invalid })
+          end
+
+          def create_city
+            @ctx[:model] = City.create(@ctx['contract.default'].values.data)
+            return Success({ ctx: @ctx, type: :created }) if @ctx[:model].persisted?
+
+            Failure({ ctx: @ctx, type: :invalid, model: true })
+          end
+
+          def includes
+            @ctx[:include] = %w[neighborhoods]
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/cities/operations/destroy.rb
+++ b/app/concepts/api/v1/cities/operations/destroy.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Cities
+      module Operations
+        class Destroy < ApplicationOperation
+          include Dry::Transaction
+
+          tee :params
+          step :validate_schema
+          tee :model
+          step :discard_cities
+
+          def params(input)
+            @ctx = {}
+            @params = to_snake_case(input[:params])
+          end
+
+          def validate_schema
+            @ctx['contract.default'] = Api::V1::Cities::Contracts::Destroy.kall(@params)
+            is_valid = @ctx['contract.default'].success?
+            return Success({ ctx: @ctx, type: :success }) if is_valid
+
+            Failure({ ctx: @ctx, type: :invalid }) unless is_valid
+          end
+
+          def model
+            @ctx[:model] = State.kept.where(id: @ctx['contract.default']['cities_ids'])
+          end
+
+          def discard_cities
+            ActiveRecord::Base.transaction do
+              @ctx[:model].discard_all
+              Success({ ctx: @ctx, type: :success })
+            end
+          rescue StandardError => e
+            Failure({ ctx: @ctx, type: :invalid })
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/cities/operations/index.rb
+++ b/app/concepts/api/v1/cities/operations/index.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Cities
+      module Operations
+        class Index < ApplicationOperation
+          include Dry::Transaction
+
+          tee :params
+          step :validate_schema
+          tee :cursor_and_paginate
+          step :list
+          tee :page_pagination?
+          tee :paginate
+          tee :includes
+          tee :meta
+
+          def params(input)
+            @ctx = {}
+            @params = to_snake_case(input[:params])
+          end
+
+          def validate_schema
+            @ctx['contract.default'] = Api::V1::Cities::Contracts::Index.kall(@params)
+            is_valid = @ctx['contract.default'].success?
+            return Success({ ctx: @ctx, type: :success }) if is_valid
+
+            Failure({ ctx: @ctx, type: :invalid }) unless is_valid
+          end
+
+          def cursor_and_paginate
+            @ctx[:sort] = { field: 'Cities.name', direction: 'asc' }
+          end
+
+          def list
+            @ctx[:data] = Api::V1::Cities::Queries::Index.call(@ctx['contract.default']['filter'], @ctx[:sort], @params)
+            Success({ ctx: @ctx, type: :success })
+          end
+
+          def page_pagination?
+            @params.dig(:page, :is_cursor)
+          end
+
+          def paginate
+            @pagy = Api::V1::Lib::Paginates::Paginate.kall(ctx: @ctx, model: @ctx[:data], params: @params.slice("page"))
+            Success({ ctx: @ctx, type: :success })
+          end
+
+          def includes
+            @ctx[:include] = ['neighborhoods']
+          end
+
+          def meta
+            @ctx[:meta] = {
+              total: @ctx[:pagy].count
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/cities/operations/show.rb
+++ b/app/concepts/api/v1/cities/operations/show.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Cities
+      module Operations
+        class Show < ApplicationOperation
+          include Dry::Transaction
+
+          tee :params
+          step :find_city
+          tee :includes
+
+          def params(input)
+            @ctx = {}
+            @params = to_snake_case(input[:params])
+          end
+
+          def find_city
+            @ctx[:data] = City.find_by(id: @params[:id], country_id: @params['country_id'], state_id: @params['state_id'],  discarded_at: nil)
+            if @ctx[:data].nil?
+              Failure({ ctx: @ctx, type: :not_found })
+            else
+              Success({ ctx: @ctx, type: :success })
+            end
+          end
+
+          def includes
+            @ctx[:include] = ['neighborhoods']
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/cities/operations/update.rb
+++ b/app/concepts/api/v1/cities/operations/update.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Cities
+      module Operations
+        class Update < ApplicationOperation
+          include Dry::Transaction
+
+          tee :params
+          step :validate_schema
+          step :model
+          step :update_city
+          tee :includes
+
+          def params(input)
+            @ctx = {}
+            @params = to_snake_case(input[:params])
+          end
+
+          def validate_schema
+            @ctx['contract.default'] = Api::V1::Cities::Contracts::Update.kall(@params)
+            is_valid = @ctx['contract.default'].success?
+            return Success({ ctx: @ctx, type: :success }) if is_valid
+
+            Failure({ ctx: @ctx, type: :invalid })
+          end
+
+          def model
+            @ctx[:model] = City.kept.find_by(id: @params[:id], state_id: @params[:state_id], country_id: @params[:country_id])
+            return Success({ ctx: @ctx, type: :success }) if @ctx[:model]
+
+            add_errors(@ctx['contract.default'].errors,nil, I18n.t('errors.users.not_found'),
+                       custom_predicate: :not_found?)
+            Failure({ ctx: @ctx, type: :invalid, model: true }) unless @ctx[:model]
+          end
+
+          def update_neighborhoods
+            neighborhood_ids = @ctx['contract.default'].values.data[:neighborhoods_attributes].pluck(:_destroy)
+            city_id = @ctx['contract.default'].values.data[:id]
+            Neighborhood.where(city_id: city_id, id: neighborhood_ids).discard_all
+          end
+
+          def update_city
+            ActiveRecord::Base.transaction do
+              begin
+                @ctx[:model].update!(@ctx['contract.default'].values.data)
+                update_neighborhoods
+                Success({ ctx: @ctx, type: :success })
+              rescue ActiveRecord::RecordInvalid => invalid
+                add_errors(@ctx['contract.default'].errors,nil, I18n.t('errors.users.not_found'),
+                           custom_predicate: :not_found?)
+                Failure({ ctx: @ctx, type: :invalid, model: true })
+                raise ActiveRecord::Rollback
+              end
+            end
+          end
+
+          def includes
+            @ctx[:include] = ['neighborhoods']
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/cities/queries/index.rb
+++ b/app/concepts/api/v1/cities/queries/index.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Cities
+      module Queries
+        class Index
+          include Api::V1::Lib::Queries::QueryHelper
+
+          def initialize(filter, sort, params)
+            @model = City
+            @filter = filter
+            @sort = sort
+            @params = params
+          end
+
+          def self.call(...)
+            new(...).call
+          end
+
+          def call
+            @model.where(discarded_at: nil)
+                  .yield_self(&method(:name_clause))
+                  .yield_self(&method(:country_clause))
+                  .yield_self(&method(:state_clause))
+                  .yield_self(&method(:sort_clause))
+          end
+
+          private
+
+          attr_reader :cities, :filter, :sort
+
+          def name_clause(relation)
+            return relation if @filter.nil? || @filter[:name].blank?
+
+            relation.where('Cities.name ilike :query', query: "%#{@filter[:name]}%")
+          end
+
+          def country_clause(relation)
+            return relation if @params['country_id'].nil? || @params['country_id'].blank?
+
+            relation.where(cities: { country_id: @params['country_id'] })
+          end
+
+          def state_clause(relation)
+            return relation if @params['state_id'].nil? || @params['state_id'].blank?
+
+            relation.where(cities: { state_id: @params['state_id'] })
+          end
+
+
+          def sort_clause(relation)
+            return relation if @sort.nil? || @sort.blank?
+
+            case @sort[:field]
+            when 'name', 'status' then sort_by_status_and_name(relation, :cities)
+            when 'Cities.name' then sort_by_table_columns(relation)
+            else relation
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/cities/queries/update.rb
+++ b/app/concepts/api/v1/cities/queries/update.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Cities
+      module Queries
+        class Update
+          include Api::V1::Lib::Queries::QueryHelper
+
+          def initialize(filter, sort)
+            @model = City
+          end
+
+          def self.call(...)
+            new(...).call
+          end
+
+          def call
+            @model.where(discarded_at: nil)
+                  .yield_self(&method(:name_clause))
+          end
+
+          private
+
+          attr_reader :cities, :filter, :sort
+
+          def name_clause(relation)
+            return relation if @filter.nil? || @filter[:name].blank?
+
+            relation.where('Cities.name ilike :query', query: "%#{@filter[:name]}%")
+          end
+
+          def sort_clause(relation)
+            return relation if @sort.nil? || @sort.blank?
+
+            case @sort[:field]
+            when 'name', 'status' then sort_by_status_and_name(relation, :Cities)
+            when 'Cities.name' then sort_by_table_columns(relation)
+            else relation
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/cities/serializers/index.rb
+++ b/app/concepts/api/v1/cities/serializers/index.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Cities
+      module Serializers
+        class Index < ApplicationSerializer
+          set_type :city
+
+          attributes :name
+          has_many :neighborhoods, serializer: Neighborhood do |object|
+            object.neighborhoods.kept
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/cities/serializers/neighborhood.rb
+++ b/app/concepts/api/v1/cities/serializers/neighborhood.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Cities
+      module Serializers
+        class Neighborhood < ApplicationSerializer
+          set_type :neighborhood
+
+          attributes  :name
+
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/cities/serializers/show.rb
+++ b/app/concepts/api/v1/cities/serializers/show.rb
@@ -1,0 +1,17 @@
+module Api
+  module V1
+    module Cities
+      module Serializers
+        class Show < ApplicationSerializer
+          set_type :city
+
+          attributes :name
+
+          has_many :neighborhoods, serializer: Neighborhood do |object|
+            object.neighborhoods.kept
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/countries/contracts/create.rb
+++ b/app/concepts/api/v1/countries/contracts/create.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Countries
+      module Contracts
+        class Create < Dry::Validation::Contract
+          def self.kall(...)
+            new.call(...)
+          end
+
+          params do
+            required(:name).filled(:string)
+            optional(:states_attributes).array(:hash) do
+              optional(:name).filled(:string)
+            end
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/countries/contracts/destroy.rb
+++ b/app/concepts/api/v1/countries/contracts/destroy.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Countries
+      module Contracts
+        class Destroy < Dry::Validation::Contract
+          def self.kall(...)
+            new.call(...)
+          end
+          params do
+            required(:country_ids).filled(:array).each(:integer)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/countries/contracts/index.rb
+++ b/app/concepts/api/v1/countries/contracts/index.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Countries
+      module Contracts
+        class Index < Dry::Validation::Contract
+          def self.kall(...)
+            new.call(...)
+          end
+          params do
+            optional(:filter).maybe(:hash) do
+              optional(:name).maybe(:string)
+            end
+
+            optional(:page).maybe(:hash) do
+              optional(:is_cursor).maybe(:bool)
+            end
+
+            optional(:sort).maybe(:string)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/countries/contracts/update.rb
+++ b/app/concepts/api/v1/countries/contracts/update.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Countries
+      module Contracts
+        class Update < Dry::Validation::Contract
+          def self.kall(...)
+            new.call(...)
+          end
+
+          params do
+            required(:id).filled(:integer)
+            optional(:name).filled(:string)
+            optional(:states_attributes).array(:hash) do
+              optional(:id).filled(:integer)
+              optional(:_destroy).filled(:integer)
+            end
+          end
+
+          rule(:states_attributes).each do
+            if value[:id] && State.exists?(id: values[:id], discarded_at: nil)
+              key.failure('state already exists in this country')
+            end
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/countries/operations/create.rb
+++ b/app/concepts/api/v1/countries/operations/create.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Countries
+      module Operations
+        class Create < ApplicationOperation
+          include Dry::Transaction
+
+          tee :params
+          step :validate_schema
+          step :create_country
+          tee :includes
+
+          def params(input)
+            @ctx = {}
+            @params = to_snake_case(input[:params])
+          end
+
+          def validate_schema
+            @ctx['contract.default'] = Api::V1::Countries::Contracts::Create.kall(@params)
+            is_valid = @ctx['contract.default'].success?
+            return Success({ ctx: @ctx, type: :success }) if is_valid
+
+            Failure({ ctx: @ctx, type: :invalid })
+          end
+
+          def create_country
+            @ctx[:model] = Country.create(@ctx['contract.default'].values.data)
+            return Success({ ctx: @ctx, type: :created }) if @ctx[:model].persisted?
+
+            Failure({ ctx: @ctx, type: :invalid, model: true })
+          end
+
+          def includes
+            @ctx[:include] = %w[states]
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/countries/operations/destroy.rb
+++ b/app/concepts/api/v1/countries/operations/destroy.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Countries
+      module Operations
+        class Destroy <  ApplicationOperation
+          include Dry::Transaction
+
+          tee :params
+          step :validate_schema
+          tee :model
+          step :discard_countries
+
+          def params(input)
+            @ctx = {}
+            @params = to_snake_case(input[:params])
+          end
+
+          def validate_schema
+            @ctx['contract.default'] = Api::V1::Countries::Contracts::Destroy.kall(@params)
+            is_valid = @ctx['contract.default'].success?
+            return Success({ ctx: @ctx, type: :success }) if is_valid
+
+            Failure({ ctx: @ctx, type: :invalid }) unless is_valid
+          end
+
+
+          def model
+            @ctx[:model] = Country.kept.where(id: @ctx['contract.default']['country_ids'])
+          end
+
+          def discard_countries
+            ActiveRecord::Base.transaction do
+              @ctx[:model].discard_all
+              Success({ ctx: @ctx, type: :success })
+            end
+          rescue StandardError => e
+            Failure({ ctx: @ctx, type: :invalid })
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/countries/operations/index.rb
+++ b/app/concepts/api/v1/countries/operations/index.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Countries
+      module Operations
+        class Index < ApplicationOperation
+          include Dry::Transaction
+
+          tee :params
+          step :validate_schema
+          tee :cursor_and_paginate
+          step :list
+          tee :page_pagination?
+          tee :paginate
+          tee :includes
+          tee :meta
+
+          def params(input)
+            @ctx = {}
+            @params = to_snake_case(input[:params])
+          end
+
+          def validate_schema
+            @ctx['contract.default'] = Api::V1::Countries::Contracts::Index.kall(@params)
+            is_valid = @ctx['contract.default'].success?
+            return Success({ ctx: @ctx, type: :success }) if is_valid
+
+            Failure({ ctx: @ctx, type: :invalid }) unless is_valid
+          end
+
+          def cursor_and_paginate
+            @ctx[:sort] = { field: 'Countries.name', direction: 'asc' }
+          end
+
+          def list
+            @ctx[:data] = Api::V1::Countries::Queries::Index.call(@ctx['contract.default']['filter'], @ctx[:sort])
+            Success({ ctx: @ctx, type: :success })
+          end
+
+          def page_pagination?
+            @params.dig(:page, :is_cursor)
+          end
+
+          def paginate
+            @pagy = Api::V1::Lib::Paginates::Paginate.kall(ctx: @ctx, model: @ctx[:data], params: @params.slice("page"))
+            Success({ ctx: @ctx, type: :success })
+          end
+
+          def includes
+            @ctx[:include] = ['states']
+          end
+
+          def meta
+            @ctx[:meta] = {
+              total: @ctx[:pagy].count
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/countries/operations/show.rb
+++ b/app/concepts/api/v1/countries/operations/show.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Countries
+      module Operations
+        class Show < ApplicationOperation
+          include Dry::Transaction
+
+          tee :params
+          step :find_country
+          tee :includes
+
+          def params(input)
+            @ctx = {}
+            @params = to_snake_case(input[:params])
+          end
+
+          def find_country
+            @ctx[:data] = Country.find_by(id: @params[:id], discarded_at: nil)
+            if @ctx[:data].nil?
+              Failure({ ctx: @ctx, type: :not_found })
+            else
+              Success({ ctx: @ctx, type: :success })
+            end
+          end
+
+          def includes
+            @ctx[:include] = ['states']
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/countries/operations/update.rb
+++ b/app/concepts/api/v1/countries/operations/update.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Countries
+      module Operations
+        class Update < ApplicationOperation
+          include Dry::Transaction
+
+          tee :params
+          step :validate_schema
+          step :model
+          step :update_organization
+          tee :includes
+
+          def params(input)
+            @ctx = {}
+            @params = to_snake_case(input[:params])
+          end
+
+          def validate_schema
+            @ctx['contract.default'] = Api::V1::Countries::Contracts::Update.kall(@params)
+            is_valid = @ctx['contract.default'].success?
+            return Success({ ctx: @ctx, type: :success }) if is_valid
+
+            Failure({ ctx: @ctx, type: :invalid })
+          end
+
+          def model
+            @ctx[:model] = Country.kept.find_by(id: @params[:id])
+            return Success({ ctx: @ctx, type: :success }) if @ctx[:model]
+
+            add_errors(@ctx['contract.default'].errors,nil, I18n.t('errors.users.not_found'),
+                       custom_predicate: :not_found?)
+            Failure({ ctx: @ctx, type: :invalid, model: true }) unless @ctx[:model]
+          end
+
+          def update_states
+            state_ids = @ctx['contract.default'].values.data[:states_attributes].pluck(:_destroy)
+            country_id = @ctx['contract.default'].values.data[:id]
+            State.where(country_id: country_id, id: state_ids).discard_all
+          end
+
+          def update_organization
+            ActiveRecord::Base.transaction do
+              begin
+                @ctx[:model].update!(@ctx['contract.default'].values.data)
+                update_states
+                return Success({ ctx: @ctx, type: :success })
+              rescue ActiveRecord::RecordInvalid => invalid
+                add_errors(@ctx['contract.default'].errors,nil, I18n.t('errors.users.not_found'),
+                           custom_predicate: :not_found?)
+                Failure({ ctx: @ctx, type: :invalid, model: true })
+                raise ActiveRecord::Rollback
+              end
+            end
+          end
+
+          def includes
+            @ctx[:include] = ['states']
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/countries/queries/index.rb
+++ b/app/concepts/api/v1/countries/queries/index.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Countries
+      module Queries
+        class Index
+          include Api::V1::Lib::Queries::QueryHelper
+
+          def initialize(filter, sort)
+            @model = Country
+            @filter = filter
+            @sort = sort
+          end
+
+          def self.call(...)
+            new(...).call
+          end
+
+          def call
+            @model.where(discarded_at: nil)
+                  .yield_self(&method(:name_clause))
+                  .yield_self(&method(:sort_clause))
+          end
+
+          private
+
+          attr_reader :countries, :filter, :sort
+
+          def name_clause(relation)
+            return relation if @filter.nil? || @filter[:name].blank?
+
+            relation.where('Teams.name ilike :query', query: "%#{@filter[:name]}%")
+          end
+
+          def sort_clause(relation)
+            return relation if @sort.nil? || @sort.blank?
+
+            case @sort[:field]
+            when 'name', 'status' then sort_by_status_and_name(relation, :countries)
+            when 'Teams.name' then sort_by_table_columns(relation)
+            else relation
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/countries/queries/update.rb
+++ b/app/concepts/api/v1/countries/queries/update.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Countries
+      module Queries
+        class Update
+          include Api::V1::Lib::Queries::QueryHelper
+
+          def initialize(filter, sort)
+            @model = Country
+          end
+
+          def self.call(...)
+            new(...).call
+          end
+
+          def call
+            @model.where(discarded_at: nil)
+                  .yield_self(&method(:name_clause))
+          end
+
+          private
+
+          attr_reader :countries, :filter, :sort
+
+          def name_clause(relation)
+            return relation if @filter.nil? || @filter[:name].blank?
+
+            relation.where('Countries.name ilike :query', query: "%#{@filter[:name]}%")
+          end
+
+          def sort_clause(relation)
+            return relation if @sort.nil? || @sort.blank?
+
+            case @sort[:field]
+            when 'name', 'status' then sort_by_status_and_name(relation, :Countries)
+            when 'Countries.name' then sort_by_table_columns(relation)
+            else relation
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/countries/serializers/index.rb
+++ b/app/concepts/api/v1/countries/serializers/index.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Countries
+      module Serializers
+        class Index < ApplicationSerializer
+          set_type :country
+
+          attributes :name
+          has_many :states, serializer: State do |object|
+            object.neighborhoods.kept
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/countries/serializers/show.rb
+++ b/app/concepts/api/v1/countries/serializers/show.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Countries
+      module Serializers
+        class Show < ApplicationSerializer
+          set_type :country
+
+          attributes :name
+          has_many :states, serializer: State do |object|
+            object.neighborhoods.kept
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/countries/serializers/state.rb
+++ b/app/concepts/api/v1/countries/serializers/state.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Countries
+      module Serializers
+        class State < ApplicationSerializer
+          set_type :state
+
+          attributes  :name
+
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/states/contracts/create.rb
+++ b/app/concepts/api/v1/states/contracts/create.rb
@@ -1,0 +1,29 @@
+module Api
+  module V1
+    module States
+      module Contracts
+        class Create < Dry::Validation::Contract
+          def self.kall(...)
+            new.call(...)
+          end
+
+          params do
+            required(:name).filled(:string)
+            required(:country_id).filled(:string)
+            optional(:cities_attributes).array(:hash) do
+              optional(:name).filled(:string)
+            end
+          end
+
+          rule(:cities_attributes) do
+            if value.is_a?(Array)
+              value.each do |city|
+                city[:country_id] = values[:country_id].to_s
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/states/contracts/destroy.rb
+++ b/app/concepts/api/v1/states/contracts/destroy.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module States
+      module Contracts
+        class Destroy < Dry::Validation::Contract
+          def self.kall(...)
+            new.call(...)
+          end
+          params do
+            required(:states_ids).filled(:array).each(:integer)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/states/contracts/index.rb
+++ b/app/concepts/api/v1/states/contracts/index.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module States
+      module Contracts
+        class Index < Dry::Validation::Contract
+          def self.kall(...)
+            new.call(...)
+          end
+          params do
+            optional(:filter).maybe(:hash) do
+              optional(:name).maybe(:string)
+            end
+
+            optional(:page).maybe(:hash) do
+              optional(:is_cursor).maybe(:bool)
+            end
+
+            optional(:sort).maybe(:string)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/states/contracts/update.rb
+++ b/app/concepts/api/v1/states/contracts/update.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module States
+      module Contracts
+        class Update < Dry::Validation::Contract
+          def self.kall(...)
+            new.call(...)
+          end
+
+          params do
+            required(:id).filled(:integer)
+            optional(:name).filled(:string)
+            optional(:cities_attributes).array(:hash) do
+              optional(:id).filled(:integer)
+              optional(:_destroy).filled(:integer)
+            end
+          end
+
+          rule(:cities_attributes).each do
+            if value[:id] && State.exists?(id: values[:id], discarded_at: nil)
+              key.failure('city already exists in this state')
+            end
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/states/operations/create.rb
+++ b/app/concepts/api/v1/states/operations/create.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module States
+      module Operations
+        class Create < ApplicationOperation
+          include Dry::Transaction
+
+          tee :params
+          step :validate_schema
+          step :create_state
+          tee :includes
+
+          def params(input)
+            @ctx = {}
+            @params = to_snake_case(input[:params])
+          end
+
+          def validate_schema
+            @ctx['contract.default'] = Api::V1::States::Contracts::Create.kall(@params)
+            is_valid = @ctx['contract.default'].success?
+            return Success({ ctx: @ctx, type: :success }) if is_valid
+
+            Failure({ ctx: @ctx, type: :invalid })
+          end
+
+          def create_state
+            @ctx[:model] = State.create(@ctx['contract.default'].values.data)
+            return Success({ ctx: @ctx, type: :created }) if @ctx[:model].persisted?
+
+            Failure({ ctx: @ctx, type: :invalid, model: true })
+          end
+
+          def includes
+            @ctx[:include] = %w[cities]
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/states/operations/destroy.rb
+++ b/app/concepts/api/v1/states/operations/destroy.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module States
+      module Operations
+        class Destroy < ApplicationOperation
+          include Dry::Transaction
+
+          tee :params
+          step :validate_schema
+          tee :model
+          step :discard_states
+
+          def params(input)
+            @ctx = {}
+            @params = to_snake_case(input[:params])
+          end
+
+          def validate_schema
+            @ctx['contract.default'] = Api::V1::States::Contracts::Destroy.kall(@params)
+            is_valid = @ctx['contract.default'].success?
+            return Success({ ctx: @ctx, type: :success }) if is_valid
+
+            Failure({ ctx: @ctx, type: :invalid }) unless is_valid
+          end
+
+          def model
+            @ctx[:model] = State.kept.where(id: @ctx['contract.default']['state_ids'])
+          end
+
+          def discard_states
+            ActiveRecord::Base.transaction do
+              @ctx[:model].discard_all
+              Success({ ctx: @ctx, type: :success })
+            end
+          rescue StandardError => e
+            Failure({ ctx: @ctx, type: :invalid })
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/states/operations/index.rb
+++ b/app/concepts/api/v1/states/operations/index.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module States
+      module Operations
+        class Index < ApplicationOperation
+          include Dry::Transaction
+
+          tee :params
+          step :validate_schema
+          tee :cursor_and_paginate
+          step :list
+          tee :page_pagination?
+          tee :paginate
+          tee :includes
+          tee :meta
+
+          def params(input)
+            @ctx = {}
+            @params = to_snake_case(input[:params])
+          end
+
+          def validate_schema
+            @ctx['contract.default'] = Api::V1::States::Contracts::Index.kall(@params)
+            is_valid = @ctx['contract.default'].success?
+            return Success({ ctx: @ctx, type: :success }) if is_valid
+
+            Failure({ ctx: @ctx, type: :invalid }) unless is_valid
+          end
+
+          def cursor_and_paginate
+            @ctx[:sort] = { field: 'States.name', direction: 'asc' }
+          end
+
+          def list
+            @ctx[:data] = Api::V1::States::Queries::Index.call(@ctx['contract.default']['filter'], @ctx[:sort])
+            Success({ ctx: @ctx, type: :success })
+          end
+
+          def page_pagination?
+            @params.dig(:page, :is_cursor)
+          end
+
+          def paginate
+            @pagy = Api::V1::Lib::Paginates::Paginate.kall(ctx: @ctx, model: @ctx[:data], params: @params.slice("page"))
+            Success({ ctx: @ctx, type: :success })
+          end
+
+          def includes
+            @ctx[:include] = ['cities']
+          end
+
+          def meta
+            @ctx[:meta] = {
+              total: @ctx[:pagy].count
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/states/operations/show.rb
+++ b/app/concepts/api/v1/states/operations/show.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module States
+      module Operations
+        class Show < ApplicationOperation
+          include Dry::Transaction
+
+          tee :params
+          step :find_state
+          tee :includes
+
+          def params(input)
+            @ctx = {}
+            @params = to_snake_case(input[:params])
+          end
+
+          def find_state
+            @ctx[:data] = State.find_by(id: @params[:id], discarded_at: nil)
+            if @ctx[:data].nil?
+              Failure({ ctx: @ctx, type: :not_found })
+            else
+              Success({ ctx: @ctx, type: :success })
+            end
+          end
+
+          def includes
+            @ctx[:include] = ['cities']
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/states/operations/update.rb
+++ b/app/concepts/api/v1/states/operations/update.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module States
+      module Operations
+        class Update < ApplicationOperation
+          include Dry::Transaction
+
+          tee :params
+          step :validate_schema
+          step :model
+          step :update_state
+          tee :includes
+
+          def params(input)
+            @ctx = {}
+            @params = to_snake_case(input[:params])
+          end
+
+          def validate_schema
+            @ctx['contract.default'] = Api::V1::States::Contracts::Update.kall(@params)
+            is_valid = @ctx['contract.default'].success?
+            return Success({ ctx: @ctx, type: :success }) if is_valid
+
+            Failure({ ctx: @ctx, type: :invalid })
+          end
+
+          def model
+            @ctx[:model] = State.kept.find_by(id: @params[:id])
+            return Success({ ctx: @ctx, type: :success }) if @ctx[:model]
+
+            add_errors(@ctx['contract.default'].errors,nil, I18n.t('errors.users.not_found'),
+                       custom_predicate: :not_found?)
+            Failure({ ctx: @ctx, type: :invalid, model: true }) unless @ctx[:model]
+          end
+
+          def update_cities
+            city_ids = @ctx['contract.default'].values.data[:cities_attributes].pluck(:_destroy)
+            state_id = @ctx['contract.default'].values.data[:id]
+            City.where(state_id: state_id, id: city_ids).discard_all
+          end
+
+          def update_state
+            ActiveRecord::Base.transaction do
+              begin
+                @ctx[:model].update!(@ctx['contract.default'].values.data)
+                update_cities
+                return Success({ ctx: @ctx, type: :success })
+              rescue ActiveRecord::RecordInvalid => invalid
+                add_errors(@ctx['contract.default'].errors,nil, I18n.t('errors.users.not_found'),
+                           custom_predicate: :not_found?)
+                Failure({ ctx: @ctx, type: :invalid, model: true })
+                raise ActiveRecord::Rollback
+              end
+            end
+          end
+
+          def includes
+            @ctx[:include] = ['cities']
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/states/queries/index.rb
+++ b/app/concepts/api/v1/states/queries/index.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module States
+      module Queries
+        class Index
+          include Api::V1::Lib::Queries::QueryHelper
+
+          def initialize(filter, sort)
+            @model = State
+            @filter = filter
+            @sort = sort
+          end
+
+          def self.call(...)
+            new(...).call
+          end
+
+          def call
+            @model.where(discarded_at: nil)
+                  .yield_self(&method(:name_clause))
+                  .yield_self(&method(:sort_clause))
+          end
+
+          private
+
+          attr_reader :countries, :filter, :sort
+
+          def name_clause(relation)
+            return relation if @filter.nil? || @filter[:name].blank?
+
+            relation.where('States.name ilike :query', query: "%#{@filter[:name]}%")
+          end
+
+          def sort_clause(relation)
+            return relation if @sort.nil? || @sort.blank?
+
+            case @sort[:field]
+            when 'name', 'status' then sort_by_status_and_name(relation, :countries)
+            when 'States.name' then sort_by_table_columns(relation)
+            else relation
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/states/queries/update.rb
+++ b/app/concepts/api/v1/states/queries/update.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module States
+      module Queries
+        class Update
+          include Api::V1::Lib::Queries::QueryHelper
+
+          def initialize(filter, sort)
+            @model = Country
+          end
+
+          def self.call(...)
+            new(...).call
+          end
+
+          def call
+            @model.where(discarded_at: nil)
+                  .yield_self(&method(:name_clause))
+          end
+
+          private
+
+          attr_reader :states, :filter, :sort
+
+          def name_clause(relation)
+            return relation if @filter.nil? || @filter[:name].blank?
+
+            relation.where('States.name ilike :query', query: "%#{@filter[:name]}%")
+          end
+
+          def sort_clause(relation)
+            return relation if @sort.nil? || @sort.blank?
+
+            case @sort[:field]
+            when 'name', 'status' then sort_by_status_and_name(relation, :States)
+            when 'States.name' then sort_by_table_columns(relation)
+            else relation
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/states/serializers/city.rb
+++ b/app/concepts/api/v1/states/serializers/city.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module States
+      module Serializers
+        class City < ApplicationSerializer
+          set_type :city
+
+          attributes  :name
+
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/states/serializers/index.rb
+++ b/app/concepts/api/v1/states/serializers/index.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module States
+      module Serializers
+        class Index < ApplicationSerializer
+          set_type :state
+
+          attributes :name
+          has_many :cities, serializer: City do |object|
+            object.neighborhoods.kept
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/states/serializers/show.rb
+++ b/app/concepts/api/v1/states/serializers/show.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module States
+      module Serializers
+        class Show < ApplicationSerializer
+          set_type :state
+
+          attributes :name
+          has_many :cities, serializer: City do |object|
+            object.neighborhoods.kept
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/users/accounts/contracts/create.rb
+++ b/app/concepts/api/v1/users/accounts/contracts/create.rb
@@ -19,7 +19,7 @@ module Api
               required(:user_profile).hash do
                 required(:first_name).filled(:string)
                 required(:last_name).filled(:string)
-                required(:gender).filled(:string)
+                required(:gender).filled(:integer)
                 required(:country).filled(:string)
                 required(:city).filled(:string)
                 required(:language).filled(:string)

--- a/app/controllers/api/v1/admin/cities_controller.rb
+++ b/app/controllers/api/v1/admin/cities_controller.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Admin
+      class CitiesController < ApiController
+
+        def index
+          endpoint operation: Api::V1::Cities::Operations::Index,
+                   renderer_options: { serializer: Api::V1::Cities::Serializers::Index },
+                   options: { current_user: }
+        end
+
+        def show
+          endpoint operation: Api::V1::Cities::Operations::Show,
+                   renderer_options: { serializer: Api::V1::Cities::Serializers::Show },
+                   options: { current_user: }
+        end
+
+        def create
+          endpoint operation: Api::V1::Cities::Operations::Create,
+                   renderer_options: { serializer: Api::V1::Cities::Serializers::Show },
+                   options: { current_user: }
+        end
+
+        def update
+          endpoint operation: Api::V1::Cities::Operations::Update,
+                   renderer_options: { serializer: Api::V1::Cities::Serializers::Show },
+                   options: { current_user: }
+        end
+
+        def destroy
+          endpoint operation: Api::V1::Cities::Operations::Destroy,
+                   options: { current_user: }
+        end
+
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/admin/countries_controller.rb
+++ b/app/controllers/api/v1/admin/countries_controller.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Admin
+      class CountriesController < ApiController
+
+        def index
+          endpoint operation: Api::V1::Countries::Operations::Index,
+                   renderer_options: { serializer: Api::V1::Countries::Serializers::Index },
+                   options: { current_user: }
+        end
+
+        def show
+          endpoint operation: Api::V1::Countries::Operations::Show,
+                   renderer_options: { serializer: Api::V1::Countries::Serializers::Show },
+                   options: { current_user: }
+        end
+
+        def create
+          endpoint operation: Api::V1::Countries::Operations::Create,
+                   renderer_options: { serializer: Api::V1::Countries::Serializers::Show },
+                   options: { current_user: }
+        end
+
+        def update
+          endpoint operation: Api::V1::Countries::Operations::Update,
+                   renderer_options: { serializer: Api::V1::Countries::Serializers::Show },
+                   options: { current_user: }
+        end
+
+        def destroy
+          endpoint operation: Api::V1::Countries::Operations::Destroy,
+                   options: { current_user: }
+        end
+
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/admin/states_controller.rb
+++ b/app/controllers/api/v1/admin/states_controller.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Admin
+      class StatesController < ApiController
+
+        def index
+          endpoint operation: Api::V1::States::Operations::Index,
+                   renderer_options: { serializer: Api::V1::States::Serializers::Index },
+                   options: { current_user: }
+        end
+
+        def show
+          endpoint operation: Api::V1::States::Operations::Show,
+                   renderer_options: { serializer: Api::V1::States::Serializers::Show },
+                   options: { current_user: }
+        end
+
+        def create
+          endpoint operation: Api::V1::States::Operations::Create,
+                   renderer_options: { serializer: Api::V1::States::Serializers::Show },
+                   options: { current_user: }
+        end
+
+        def update
+          endpoint operation: Api::V1::States::Operations::Update,
+                   renderer_options: { serializer: Api::V1::States::Serializers::Show },
+                   options: { current_user: }
+        end
+
+        def destroy
+          endpoint operation: Api::V1::States::Operations::Destroy,
+                   options: { current_user: }
+        end
+
+      end
+    end
+  end
+end

--- a/app/models/city.rb
+++ b/app/models/city.rb
@@ -29,4 +29,6 @@ class City < ApplicationRecord
   belongs_to :country
 
   has_many :neighborhoods, dependent: :destroy
+  accepts_nested_attributes_for :neighborhoods, allow_destroy: true
+
 end

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -17,4 +17,6 @@ class Country < ApplicationRecord
   include Discard::Model
 
   has_many :states, dependent: :destroy
+  accepts_nested_attributes_for :states, allow_destroy: true
+
 end

--- a/app/models/state.rb
+++ b/app/models/state.rb
@@ -24,4 +24,6 @@ class State < ApplicationRecord
 
   belongs_to :country
   has_many :cities, dependent: :destroy
+  accepts_nested_attributes_for :cities, allow_destroy: true
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,26 @@ Rails.application.routes.draw do
             delete :destroy
           end
         end
+        resources :countries do
+          collection do
+            delete :destroy
+          end
+          resources :states do
+            collection do
+              delete :destroy
+            end
+            resources :cities do
+              collection do
+                delete :destroy
+              end
+              resources :neighborhoods do
+                collection do
+                  delete :destroy
+                end
+              end
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This commit introduces the implementation of CRUD operations (Create, Read, Update, Destroy) and their corresponding validation contracts for the country and city domains. These operations include establishing rules for required parameters and optional attributes like state and neighborhood instances under a city. Moreover, logic for pagination, sort, and filtering in Index operations is included. Each operation is also associated with relevant serializer classes for model attribute presentation.