### PR TITLE
Refactor user validation and correct serializers

### DIFF
--- a/app/concepts/api/v1/countries/serializers/index.rb
+++ b/app/concepts/api/v1/countries/serializers/index.rb
@@ -9,7 +9,7 @@ module Api
 
           attributes :name
           has_many :states, serializer: State do |object|
-            object.neighborhoods.kept
+            object.states.kept
           end
         end
       end

--- a/app/concepts/api/v1/states/serializers/index.rb
+++ b/app/concepts/api/v1/states/serializers/index.rb
@@ -9,7 +9,7 @@ module Api
 
           attributes :name
           has_many :cities, serializer: City do |object|
-            object.neighborhoods.kept
+            object.cities.kept
           end
         end
       end

--- a/app/concepts/api/v1/users/accounts/contracts/create.rb
+++ b/app/concepts/api/v1/users/accounts/contracts/create.rb
@@ -18,7 +18,7 @@ module Api
               required(:user_profile).hash do
                 required(:first_name).filled(:string)
                 required(:last_name).filled(:string)
-                required(:gender).filled(:integer)
+                optional(:gender).filled(:integer)
                 required(:city_id).filled(:integer)
                 required(:neighborhood_id).filled(:integer)
                 required(:organization_id).filled(:integer)
@@ -32,6 +32,18 @@ module Api
               if value[:email]
                 if UserProfile.exists?(['LOWER(email) = ?', value[:email].downcase])
                   key(:email).failure(text: :user_email_unique?,  predicate: :user_email_unique?)
+                end
+              end
+
+              if value[:neighborhood_id]
+                unless Neighborhood.exists?(id: value[:neighborhood_id])
+                  key(:neighborhood_id).failure(text: 'neighborhood not exists',  predicate: :user_email_unique?)
+                end
+              end
+
+              if value[:city_id]
+                unless City.exists?(id: value[:city_id])
+                  key(:city_id).failure(text: 'city not exists',  predicate: :user_email_unique?)
                 end
               end
             end

--- a/app/concepts/api/v1/users/sessions/contracts/create.rb
+++ b/app/concepts/api/v1/users/sessions/contracts/create.rb
@@ -1,12 +1,11 @@
-# frozen_string_literal: true
+require 'dry/validation/contract'
 
 module Api
   module V1
     module Users
-      module Sessions
+      module Accounts
         module Contracts
           class Create < Dry::Validation::Contract
-
             def self.kall(...)
               new.call(...)
             end
@@ -14,19 +13,54 @@ module Api
             params do
               optional(:phone).filled(:string)
               optional(:username).filled(:string)
-              required(:password).filled(:string)
-              required(:type).filled(:string, included_in?: %w[phone username])
-            end
+              required(:password).filled(:string, min_size?: Constants::User::PASSWORD_MIN_LENGTH)
 
-            rule(:phone) do |type, phone|
-              if values[:type].eql?('phone') && values[:phone].nil?
-                key.failure(text: :user_credential_requirement, predicate: :filled?)
+              required(:user_profile).hash do
+                required(:first_name).filled(:string)
+                required(:last_name).filled(:string)
+                required(:gender).filled(:integer)
+                required(:city_id).filled(:integer)
+                required(:neighborhood_id).filled(:integer)
+                required(:organization_id).filled(:integer)
+                optional(:timezone).filled(:string)
+                optional(:language).filled(:string)
+                optional(:email).filled(:string)
               end
             end
 
-            rule( :username) do |type, username|
-              if values[:type].eql?('username') && values[:username].nil?
-                key.failure(text: :user_credential_requirement?, predicate: :filled?)
+            rule(:user_profile) do
+              if value[:email]
+                if UserProfile.exists?(['LOWER(email) = ?', value[:email].downcase])
+                  key(:email).failure(text: :user_email_unique?,  predicate: :user_email_unique?)
+                end
+              end
+
+              if value[:neighborhood_id]
+                unless Neighborhood.exists?(id: value[:neighborhood_id])
+                  key(:neighborhood_id).failure(text: 'neighborhood not exists',  predicate: :user_email_unique?)
+                end
+              end
+
+              if value[:city_id]
+                unless City.exists?(id: value[:city_id])
+                  key(:city_id).failure(text: 'city not exists',  predicate: :user_email_unique?)
+                end
+              end
+            end
+
+            rule(:phone) do
+              if values[:phone].nil? && values[:username].nil?
+                key(:phone).failure(text: :user_credential_requirement, predicate: :credentials_wrong?)
+              elsif values[:phone] && UserAccount.exists?(phone: values[:phone])
+                key.failure(text: :user_phone_unique?, predicate: :user_phone_unique?)
+              end
+            end
+
+            rule(:username) do
+              if values[:username].nil? && values[:phone].nil?
+                key(:username).failure(text: :user_credential_requirement, predicate: :credentials_wrong?)
+              elsif values[:username] && UserAccount.exists?(username: value)
+                key.failure(text: :user_username_unique?, predicate: :user_username_unique?)
               end
             end
 


### PR DESCRIPTION
Refactoring was performed on the user account validation logic to handle optional gender and to add entity existence checks for neighborhood and city references. The serializer in country and state modules incorrectly referenced kept neighborhoods. This has been corrected to reference kept states and cities respectively.