### PR TITLE
Refactor module name from Accounts to Sessions

### DIFF
--- a/app/concepts/api/v1/users/sessions/contracts/create.rb
+++ b/app/concepts/api/v1/users/sessions/contracts/create.rb
@@ -3,7 +3,7 @@ require 'dry/validation/contract'
 module Api
   module V1
     module Users
-      module Accounts
+      module Sessions
         module Contracts
           class Create < Dry::Validation::Contract
             def self.kall(...)


### PR DESCRIPTION
In the file 'create.rb' under 'app/concepts/api/v1/users/sessions/contracts', the module name has been changed from Accounts to Sessions. This refactoring improves the context of the module, making its purpose and content clearer.