### PR TITLE
Update authentication failure types and messages

### DIFF
--- a/app/concepts/api/v1/users/sessions/operations/create.rb
+++ b/app/concepts/api/v1/users/sessions/operations/create.rb
@@ -44,8 +44,9 @@ module Api
 
             def authenticate
               unless @ctx[:model].authenticate(@params[:password])
-                add_errors(@ctx['contract.default'].errors,'', 'unauthorized', '',[], :user_account_without_confirmation?)
-                return Failure({ ctx: @ctx, type: :invalid })
+                add_errors(@ctx['contract.default'].errors,'', I18n.t('errors.session.wrong_credentials'), '',[], :credentials_wrong?)
+
+                return Failure({ ctx: @ctx, type: :unauthenticated })
               end
               Success({ ctx: @ctx, type: :success })
             end
@@ -56,8 +57,8 @@ module Api
               if is_active
                 Success({ ctx: @ctx, type: :success })
               else
-                add_errors(@ctx['contract.default'].errors,nil, I18n.t('errors.unauthorized'))
-                Failure({ ctx: @ctx, type: :unauthenticated })
+                add_errors(@ctx['contract.default'].errors,'', 'unauthorized', '',[], :user_account_without_confirmation?)
+                Failure({ ctx: @ctx, type: :invalid })
               end
             end
 


### PR DESCRIPTION
This commit updates the failure types and error messages for user authentication. It provides more detailed responses when authentication fails, making use of differing error types and messages depending on whether the failure is due to wrong credentials or a user account without confirmation.