### PR TITLE
Add API endpoint for role retrieval

### DIFF
--- a/app/concepts/api/v1/roles/contracts/index.rb
+++ b/app/concepts/api/v1/roles/contracts/index.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Roles
+      module Contracts
+        class Index < Dry::Validation::Contract
+          def self.kall(...)
+            new.call(...)
+          end
+          params do
+            optional(:filter).maybe(:hash) do
+              optional(:name).maybe(:string)
+            end
+
+            optional(:page).maybe(:hash) do
+              optional(:is_cursor).maybe(:bool)
+            end
+
+            optional(:sort).maybe(:string)
+            optional(:order).maybe(:string, included_in?: %w[asc desc])
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/roles/operations/index.rb
+++ b/app/concepts/api/v1/roles/operations/index.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Roles
+      module Operations
+        class Index < ApplicationOperation
+          include Dry::Transaction
+
+          tee :params
+          step :validate_schema
+          tee :cursor_and_paginate
+          step :list
+          #tee :includes
+          tee :page_pagination?
+          tee :paginate
+          tee :meta
+
+          def params(input)
+            @ctx = {}
+            @params = to_snake_case(input[:params])
+          end
+
+          def validate_schema
+            @ctx['contract.default'] = Api::V1::Roles::Contracts::Index.kall(@params)
+            is_valid = @ctx['contract.default'].success?
+            return Success({ ctx: @ctx, type: :success }) if is_valid
+
+            Failure({ ctx: @ctx, type: :invalid }) unless is_valid
+          end
+
+          def cursor_and_paginate
+            @ctx[:sort] = { field: @params['sort'], direction: @params['order'] }
+          end
+
+          def list
+            @ctx[:data] = Api::V1::Roles::Queries::Index.call(@ctx['contract.default']['filter'], @ctx[:sort])
+            Success({ ctx: @ctx, type: :success })
+          end
+
+          def page_pagination?
+            @params.dig(:page, :is_cursor)
+          end
+
+          def paginate
+            @pagy = Api::V1::Lib::Paginates::Paginate.kall(ctx: @ctx, model: @ctx[:data], params: @params.slice("page"))
+            Success({ ctx: @ctx, type: :success })
+          end
+
+          def includes
+            @ctx[:include] = ['permissions']
+          end
+
+          def meta
+            @ctx[:meta] = {
+              total: @ctx[:pagy].count
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/roles/queries/index.rb
+++ b/app/concepts/api/v1/roles/queries/index.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Roles
+      module Queries
+        class Index
+          include Api::V1::Lib::Queries::QueryHelper
+
+          def initialize(filter, sort)
+            @model = Role.includes(:permissions)
+            @filter = filter
+            @sort = sort
+          end
+
+          def self.call(...)
+            new(...).call
+          end
+
+          def call
+            #
+            @model.yield_self(&method(:name))
+                  .yield_self(&method(:sort_clause))
+          end
+
+          private
+
+          attr_reader :roles, :filter, :sort
+
+          def active_records(relation)
+            relation.where(discarded_at: nil)
+          end
+
+          def name(relation)
+            return relation if @filter.nil? || @filter[:name].blank?
+
+            relation.where('roles.name ilike :query', query: "%#{@filter[:name]}%")
+          end
+
+          def sort_clause(relation)
+            return relation if @sort.nil? || @sort.blank?
+
+            sort_by_table_columns(relation)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/roles/serializers/index.rb
+++ b/app/concepts/api/v1/roles/serializers/index.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Roles
+      module Serializers
+        class Index < ApplicationSerializer
+          set_type :roles
+
+          attributes :id, :name
+          #          has_many :permissions, serializer: Permission
+
+          attribute :permissions do |role|
+            Permission.new(role.permissions)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/roles/serializers/permission.rb
+++ b/app/concepts/api/v1/roles/serializers/permission.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Roles
+      module Serializers
+        class Permission < ApplicationSerializer
+          set_type :permission
+
+          attributes :id, :name, :resource
+
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/roles_controller.rb
+++ b/app/controllers/api/v1/roles_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class RolesController < AuthorizedApiController
+
+      def index
+        endpoint operation: Api::V1::Roles::Operations::Index,
+                 renderer_options: {
+                   serializer: Api::V1::Roles::Serializers::Index
+                 }
+      end
+
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :users, only: %i[index]
+      resources :roles, only: %i[index]
       namespace :users do
         resource :session, only: %i[create destroy], controller: :sessions do
           post 'refresh_token'


### PR DESCRIPTION
A new API endpoint has been set up to retrieve roles, including the necessary operations, queries, and serializers. This includes the addition of a new route and its associated controller method. Additionally, a contract for validating query parameters and a serializer for permissions related to these roles have been introduced.