### PR TITLE
Feature/organization attributes

### DIFF
--- a/app/concepts/api/v1/organizations/contracts/index.rb
+++ b/app/concepts/api/v1/organizations/contracts/index.rb
@@ -11,6 +11,7 @@ module Api
           params do
             optional(:filter).maybe(:hash) do
               optional(:name).maybe(:string)
+              optional(:status).maybe(:string, included_in?: %w[active inactive all])
             end
 
             optional(:page).maybe(:hash) do

--- a/app/concepts/api/v1/organizations/serializers/index.rb
+++ b/app/concepts/api/v1/organizations/serializers/index.rb
@@ -7,7 +7,11 @@ module Api
         class Index < ApplicationSerializer
           set_type :organization
 
-          attributes :name
+          attributes :name, :created_at
+
+          attribute :status do |organization|
+            organization.discarded_at.nil?
+          end
         end
       end
     end

--- a/app/concepts/api/v1/organizations/serializers/show.rb
+++ b/app/concepts/api/v1/organizations/serializers/show.rb
@@ -7,7 +7,11 @@ module Api
         class Show < ApplicationSerializer
           set_type :organization
 
-          attributes :name
+          attributes :name, :created_at
+
+          attribute :status do |organization|
+            organization.discarded_at.nil?
+          end
         end
       end
     end


### PR DESCRIPTION
Add status filter and attribute to Organization API

The Organization API now includes status manipulation functions. There's a new attribute 'status' in the Organization serializer showing whether an organization is active or not. Also, the index query has been updated to allow querying organizations based on their status (active, inactive or all).