### PR TITLE
Feature/dng 183 login fails attemps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,9 +64,9 @@ gem 'dry-transaction'
 # Soft-delete for models
 gem 'discard', '~> 1.2'
 
-gem 'sidekiq', '~> 7.1.3'
-gem 'sidekiq-limit_fetch', '~> 4'
-gem 'sidekiq-scheduler', '~> 4'
+gem 'sidekiq'
+gem 'sidekiq-limit_fetch'
+gem 'sidekiq-scheduler'
 
 # External API's
 gem 'httparty'

--- a/app/concepts/api/v1/users/lib/login_attempt.rb
+++ b/app/concepts/api/v1/users/lib/login_attempt.rb
@@ -16,12 +16,12 @@ module Api
 
           def increase_attempts_count!
             @user.increment!(:failed_attempts)
-            lock_account! if @user.failed_attempts >= 3
+            lock_account! if @user.failed_attempts >= Configuration.attempts_number
           end
 
           def lock_account!
             @user.update(status: 'locked')
-            ::Users::UnlockAccountWorker.perform_in(1.minutes, @user.id)
+            ::Users::UnlockAccountWorker.perform_in(Configuration.time_locked.minutes, @user.id)
           end
 
           def reset_attempts_count!

--- a/app/concepts/api/v1/users/lib/login_attempt.rb
+++ b/app/concepts/api/v1/users/lib/login_attempt.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Users
+      module Lib
+        class LoginAttempt
+
+          def initialize(user)
+            @user = user
+          end
+
+          def self.call(user)
+            new(user)
+          end
+
+          def increase_attempts_count!
+            @user.increment!(:failed_attempts)
+            lock_account! if @user.failed_attempts >= 3
+          end
+
+          def lock_account!
+            @user.update(status: 'locked')
+            ::Users::UnlockAccountWorker.perform_in(1.minutes, @user.id)
+          end
+
+          def reset_attempts_count!
+            @user.update(failed_attempts: 0, status: 'active')
+          end
+
+
+        end
+
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/users/sessions/operations/create.rb
+++ b/app/concepts/api/v1/users/sessions/operations/create.rb
@@ -45,6 +45,8 @@ module Api
 
             def authenticate
               unless @ctx[:model].authenticate(@params[:password])
+                Api::V1::Users::Lib::LoginAttempt.call(@ctx[:model]).increase_attempts_count!
+
                 return Failure({ ctx: @ctx, type: :unauthenticated, errors: ErrorFormater.new_error(field: :base, msg: I18n.t('errors.session.wrong_credentials'), custom_predicate: :credentials_wrong?) })
               end
 

--- a/app/concepts/api/v1/users/sessions/operations/create.rb
+++ b/app/concepts/api/v1/users/sessions/operations/create.rb
@@ -11,8 +11,8 @@ module Api
             tee :params
             step :validate_schema
             step :model
-            step :authenticate
             step :check_account_status
+            step :authenticate
             tee :access_expiration
             step :create_tokens
 
@@ -43,6 +43,16 @@ module Api
               Success({ ctx: @ctx, type: :success })
             end
 
+            def check_account_status
+              if @ctx[:model].active?
+                Success({ ctx: @ctx, type: :success })
+              elsif @ctx[:model].inactive?
+                Failure({ ctx: @ctx, type: :invalid, errors: ErrorFormater.new_error(field: :base, msg: 'your account is inactive', custom_predicate: :user_account_without_confirmation? )})
+              else
+                Failure({ ctx: @ctx, type: :invalid, errors: ErrorFormater.new_error(field: :base, msg: 'your account is locked', custom_predicate: :user_account_locked? )})
+              end
+            end
+
             def authenticate
               unless @ctx[:model].authenticate(@params[:password])
                 Api::V1::Users::Lib::LoginAttempt.call(@ctx[:model]).increase_attempts_count!
@@ -51,14 +61,6 @@ module Api
               end
 
               Success({ ctx: @ctx, type: :success })
-            end
-
-            def check_account_status
-              if @ctx[:model].active?
-                Success({ ctx: @ctx, type: :success })
-              else
-                Failure({ ctx: @ctx, type: :invalid, errors: ErrorFormater.new_error(field: :base, msg: 'your account is inactive', custom_predicate: :user_account_without_confirmation? )})
-              end
             end
 
             def access_expiration

--- a/app/models/configuration.rb
+++ b/app/models/configuration.rb
@@ -11,4 +11,23 @@
 class Configuration < ApplicationRecord
   include Discard::Model
 
+
+  def self.attempts_number
+    Rails.cache.fetch('attempts_number', expires_in: 12.hours) do
+      Configuration.find_by(field_name: 'attempts_number')&.value&.to_i || 5
+    end
+  end
+
+  def competing_price
+    Rails.cache.fetch("#{cache_key_with_version}/competing_price", expires_in: 12.hours) do
+      Competitor::API.find_price(id)
+    end
+  end
+
+  def self.time_locked
+    Rails.cache.fetch('time_locked', expires_in: 12.hours) do
+      Configuration.find_by(field_name: 'time_locked')&.value&.to_i || 10
+    end
+  end
+
 end

--- a/app/models/configuration.rb
+++ b/app/models/configuration.rb
@@ -1,0 +1,14 @@
+# == Schema Information
+#
+# Table name: configurations
+#
+#  id         :bigint           not null, primary key
+#  field_name :string           not null
+#  value      :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+class Configuration < ApplicationRecord
+  include Discard::Model
+
+end

--- a/app/models/user_account.rb
+++ b/app/models/user_account.rb
@@ -6,6 +6,7 @@
 #
 #  id              :bigint           not null, primary key
 #  discarded_at    :datetime
+#  failed_attempts :integer          default(0)
 #  password_digest :string
 #  phone           :string
 #  status          :integer          default("pending")

--- a/app/models/user_profile.rb
+++ b/app/models/user_profile.rb
@@ -17,18 +17,21 @@
 #  city_id         :bigint
 #  neighborhood_id :bigint
 #  organization_id :bigint
+#  team_id         :bigint
 #
 # Indexes
 #
 #  index_user_profiles_on_city_id          (city_id)
 #  index_user_profiles_on_neighborhood_id  (neighborhood_id)
 #  index_user_profiles_on_organization_id  (organization_id)
+#  index_user_profiles_on_team_id          (team_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (city_id => cities.id)
 #  fk_rails_...  (neighborhood_id => neighborhoods.id)
 #  fk_rails_...  (organization_id => organizations.id)
+#  fk_rails_...  (team_id => teams.id)
 #
 class UserProfile < ApplicationRecord
   has_one :user_account, dependent: :destroy, autosave: true

--- a/app/workers/users/unlock_account_worker.rb
+++ b/app/workers/users/unlock_account_worker.rb
@@ -1,0 +1,13 @@
+# app/workers/lock_account_worker.rb
+
+module Users
+  class UnlockAccountWorker
+    include Sidekiq::Worker
+
+    def perform(user_id)
+      user = UserAccount.find_by(id: user_id)
+      Api::V1::Users::Lib::LoginAttempt.call(user).reset_attempts_count!
+    end
+  end
+
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,5 +43,7 @@ module DenguechatPlus
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
     config.redis_url = ENV.fetch('REDIS_URL', nil)
+    config.active_job.queue_adapter = :sidekiq
+    config.middleware.use ActionDispatch::Session::CookieStore
   end
 end

--- a/config/initializers/constants/error_codes.rb
+++ b/config/initializers/constants/error_codes.rb
@@ -56,7 +56,8 @@ module Constants
       user_account_without_confirmation?: 51,
       unique?: 52,
       not_exists?: 53,
-      not_found?: 54
+      not_found?: 54,
+      user_account_locked?: 55
     }.freeze
   end
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sidekiq.configure_server do |config|
+  config.redis = { url: ENV.fetch('REDIS_URL', 'redis://127.0.0.1:6379/0') }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { url: ENV.fetch('REDIS_URL', 'redis://127.0.0.1:6379/0') }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'sidekiq/web'
+
 Rails.application.routes.draw do
   get 'up' => 'rails/health#show', as: :rails_health_check
   get 'health' => 'health_checks#show', as: :health_check
@@ -60,4 +62,6 @@ Rails.application.routes.draw do
       end
     end
   end
+
+  mount Sidekiq::Web => "/sidekiq"
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,14 @@
+---
+  :concurrency: 5
+  :pidfile: tmp/pids/sidekiq.pid
+  :max_retries: 3
+
+  production:
+    :concurrency: 20
+
+  :queues:
+    - default
+    - mailers
+
+  :process_limits:
+    mailers: 1

--- a/db/migrate/20240718083010_create_configuration.rb
+++ b/db/migrate/20240718083010_create_configuration.rb
@@ -1,0 +1,9 @@
+class CreateConfiguration < ActiveRecord::Migration[7.1]
+  def change
+    create_table :configurations do |t|
+      t.string :field_name, null: false
+      t.string :value
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240718083902_add_failed_attemps_to_user_account.rb
+++ b/db/migrate/20240718083902_add_failed_attemps_to_user_account.rb
@@ -1,0 +1,5 @@
+class AddFailedAttempsToUserAccount < ActiveRecord::Migration[7.1]
+  def change
+    add_column :user_accounts, :failed_attempts, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_17_051134) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_18_083902) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -25,6 +25,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_17_051134) do
     t.index ["name", "discarded_at"], name: "index_cities_on_name_and_discarded_at", unique: true
     t.index ["state_id", "country_id", "discarded_at"], name: "index_cities_on_state_id_and_country_id_and_discarded_at", unique: true
     t.index ["state_id"], name: "index_cities_on_state_id"
+  end
+
+  create_table "configurations", force: :cascade do |t|
+    t.string "field_name", null: false
+    t.string "value"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "countries", force: :cascade do |t|
@@ -137,6 +144,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_17_051134) do
     t.string "phone"
     t.string "username"
     t.integer "status", default: 0
+    t.integer "failed_attempts", default: 0
     t.index ["discarded_at"], name: "index_user_accounts_on_discarded_at"
     t.index ["phone"], name: "index_user_accounts_on_phone", unique: true
     t.index ["user_profile_id"], name: "index_user_accounts_on_user_profile_id"
@@ -164,9 +172,11 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_17_051134) do
     t.bigint "city_id"
     t.bigint "neighborhood_id"
     t.bigint "organization_id"
+    t.bigint "team_id"
     t.index ["city_id"], name: "index_user_profiles_on_city_id"
     t.index ["neighborhood_id"], name: "index_user_profiles_on_neighborhood_id"
     t.index ["organization_id"], name: "index_user_profiles_on_organization_id"
+    t.index ["team_id"], name: "index_user_profiles_on_team_id"
   end
 
   create_table "versions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -194,4 +204,5 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_17_051134) do
   add_foreign_key "user_profiles", "cities"
   add_foreign_key "user_profiles", "neighborhoods"
   add_foreign_key "user_profiles", "organizations"
+  add_foreign_key "user_profiles", "teams"
 end


### PR DESCRIPTION
Refactor login process and add configurable lockout feature

This commit introduces significant changes to the login process by moving the account status check before authentication and extending the check to include locked accounts. It also implements a configurable account lockout policy, with the maximum number of login attempts and lockout duration now requested from a new Configuration model. Lastly, a broader version constraint is set on Sidekiq-related gems.