### PR TITLE
Update Sidekiq gems to specific versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,9 +64,9 @@ gem 'dry-transaction'
 # Soft-delete for models
 gem 'discard', '~> 1.2'
 
-gem 'sidekiq'
-gem 'sidekiq-limit_fetch'
-gem 'sidekiq-scheduler'
+gem 'sidekiq', '~> 7.1.3'
+gem 'sidekiq-limit_fetch', '~> 4'
+gem 'sidekiq-scheduler', '~> 4'
 
 # External API's
 gem 'httparty'


### PR DESCRIPTION
In the Gemfile, the 'sidekiq', 'sidekiq-limit_fetch', and 'sidekiq-scheduler' gems have been updated to use specific versions. This ensures more predictable builds and potentially reduces issues related to gem versions.