### PR TITLE
Update FILTERS constant in user initializer

### DIFF
--- a/config/initializers/constants/user.rb
+++ b/config/initializers/constants/user.rb
@@ -7,7 +7,7 @@ module Constants
     ACCESS_TOKEN_EXPIRATION = 10.minutes.to_i
     PASSWORD_MIN_LENGTH = 8
     STATUS = %w[active inactive pending locked].freeze
-    FILTERS = %w[user_account.username user_account.phone user_account.created_at user_profiles.created_at user_profiles.first_name user_profiles.last_name
+    FILTERS = %w[user_account.id user_account.username user_account.phone user_account.created_at user_profiles.created_at user_profiles.first_name user_profiles.last_name
                  user_account.phone organizations.name cities.name neighborhoods.name teams.name].freeze
   end
 end


### PR DESCRIPTION
Update FILTERS constant in user initializer 

Filter options have been updated to include 'username' and 'phone' in the list of filterable fields for user accounts. This will give more flexibility when filtering user data.