### PR TITLE
Add roles and permissions attributes to serializer

### DIFF
--- a/app/concepts/api/v1/users/sessions/serializers/create.rb
+++ b/app/concepts/api/v1/users/sessions/serializers/create.rb
@@ -19,6 +19,14 @@ module Api
             has_one :city, serializer: City
             has_one :neighborhood, serializer: Neighborhood
             has_one :organization, serializer: Organization
+
+            attribute :roles do |user_account|
+              user_account.roles.map { |rol| rol.name }.join(' ')
+            end
+
+            attribute :permissions do |user_account|
+              user_account.permissions.map { |permission| "#{permission.resource}_#{permission.name}" }.join(' ')
+            end
           end
         end
       end


### PR DESCRIPTION
In the user sessions serializer, we have added two new attributes: 'roles' and 'permissions'. Now, both roles and permissions held by a user will be combined into a string and returned as part of the serialized response.