### PR TITLE
Modify role and permission serialization

### DIFF
--- a/app/concepts/api/v1/users/accounts/serializers/show_current_user.rb
+++ b/app/concepts/api/v1/users/accounts/serializers/show_current_user.rb
@@ -14,11 +14,11 @@ module Api
             has_one :user_profile, record_type: :user_profile, serializer: Api::V1::Users::Accounts::Serializers::UserProfile
 
             attribute :roles do |user_account|
-              user_account.roles.map { |rol| rol.name }.join(' ')
+              user_account.roles.map { |rol| rol.name }
             end
 
             attribute :permissions do |user_account|
-              user_account.permissions.map { |permission| "#{permission.resource}_#{permission.name}" }.join(' ')
+              user_account.permissions.map { |permission| "#{permission.resource}_#{permission.name}" }
             end
 
           end

--- a/app/concepts/api/v1/users/sessions/serializers/create.rb
+++ b/app/concepts/api/v1/users/sessions/serializers/create.rb
@@ -21,11 +21,11 @@ module Api
             has_one :organization, serializer: Organization
 
             attribute :roles do |user_account|
-              user_account.roles.map { |rol| rol.name }.join(' ')
+              user_account.roles.map { |rol| rol.name }
             end
 
             attribute :permissions do |user_account|
-              user_account.permissions.map { |permission| "#{permission.resource}_#{permission.name}" }.join(' ')
+              user_account.permissions.map { |permission| "#{permission.resource}_#{permission.name}" }
             end
           end
         end


### PR DESCRIPTION
The previous code used to present the roles and permissions of a user in a joined string format. This commit adjusts the code to return them as arrays instead, which are more manageable and easier to work with. The changes apply to both the 'show_current_user' and 'create' serializers.