### PR TITLE
Remove unused current_user option in API

### DIFF
--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -5,14 +5,12 @@ module Api
     class OrganizationsController < AuthorizedApiController
       def index
         endpoint operation: Api::V1::Organizations::Operations::Index,
-                 renderer_options: { serializer: Api::V1::Organizations::Serializers::Index },
-                 options: { current_user: }
+                 renderer_options: { serializer: Api::V1::Organizations::Serializers::Index }
       end
 
       def show
         endpoint operation: Api::V1::Organizations::Operations::Show,
-                 renderer_options: { serializer: Api::V1::Organizations::Serializers::Index },
-                 options: { current_user: }
+                 renderer_options: { serializer: Api::V1::Organizations::Serializers::Index }
       end
 
       def create


### PR DESCRIPTION
The current_user option was removed from the Organizations controller. It was not being used in the Index and Show actions for rendering. Since it was not providing any value, it's better to remove the unused code to make the codebase cleaner and easier to understand.