### PR TITLE
Add show user endpoint

### DIFF
--- a/app/concepts/api/v1/users/accounts/operations/show.rb
+++ b/app/concepts/api/v1/users/accounts/operations/show.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Users
+      module Accounts
+        module Operations
+          class Show < ApplicationOperation
+            include Dry::Transaction
+
+            tee :params
+            step :find_user
+
+            def params(input)
+              @ctx = {}
+              @params = to_snake_case(input[:params])
+            end
+
+            def find_user
+              @ctx[:data] = UserProfile.find_by(id: @params[:id])
+              if @ctx[:data].nil?
+                Failure({ ctx: @ctx, type: :not_found, errors: ErrorFormater.new_error(field: :base, msg: 'not found', custom_predicate: :not_found? )})
+
+              else
+                Success({ ctx: @ctx, type: :success })
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/users/accounts/serializers/show.rb
+++ b/app/concepts/api/v1/users/accounts/serializers/show.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Users
+      module Accounts
+        module Serializers
+          class Show < ApplicationSerializer
+            set_type :user
+
+            attributes :id,
+                       :username,
+                       :phone,
+                       :status,
+                       :email,
+                       :first_name,
+                       :last_name
+
+            attribute :created_at do |user_profile|
+              user_profile.created_at.strftime('%Y-%m-%d')
+            end
+
+            attribute :city do |user_profile|
+              next if user_profile.city.nil?
+
+              {
+                id: user_profile.city.id,
+                name: user_profile.city_name
+              }
+            end
+
+            attribute :neighborhood do |user_profile|
+              next if user_profile.neighborhood.nil?
+
+              {
+                id: user_profile.neighborhood.id,
+                name: user_profile.neighborhood_name
+              }
+            end
+
+            attribute :organization do |user_profile|
+              next if user_profile.organization.nil?
+
+              {
+                id: user_profile.organization.id,
+                name: user_profile.organization_name
+              }
+            end
+
+            attribute :team do |user_profile|
+              next if user_profile.team.nil?
+
+              {
+                id: user_profile.team.id,
+                name: user_profile.team_name
+              }
+            end
+
+            attribute :roles do |user_profile|
+              user_profile.roles&.map do |role|
+                {
+                  id: role.id,
+                  name: role.name
+                }
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -11,6 +11,11 @@ module Api
                  }
       end
 
+      def show
+        endpoint operation: Api::V1::Users::Accounts::Operations::Show,
+                 renderer_options: { serializer: Api::V1::Users::Accounts::Serializers::Show }
+      end
+
       def update
         endpoint operation: Api::V1::Users::Accounts::Operations::Update,
                  renderer_options: {

--- a/app/models/user_profile.rb
+++ b/app/models/user_profile.rb
@@ -46,4 +46,5 @@ class UserProfile < ApplicationRecord
   delegate :name, to: :organization, prefix: true, allow_nil: true
   delegate :name, to: :city, prefix: true, allow_nil: true
   delegate :name, to: :neighborhood, prefix: true, allow_nil: true
+  delegate :roles, to: :user_account, allow_nil: true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,8 +9,9 @@ Rails.application.routes.draw do
   get 'health' => 'health_checks#show', as: :health_check
   namespace :api do
     namespace :v1 do
-      resources :users, only: %i[index update] do
+      resources :users, only: %i[index update show] do
         get 'me', on: :collection, action: :show_current_user
+        get 'get_by_id/:id', on: :collection, action: :show
       end
       resources :roles, only: %i[index update create]
       namespace :users do


### PR DESCRIPTION
Added a new 'show' endpoint to the users API for displaying individual user profiles. This involved creating and integrating the corresponding operation, serializer, and route. Roles have also been delegated to the user account in the UserProfile model.