### PR TITLE
Add password parameter to user account update

### DIFF
--- a/app/concepts/api/v1/users/accounts/contracts/update.rb
+++ b/app/concepts/api/v1/users/accounts/contracts/update.rb
@@ -13,6 +13,7 @@ module Api
             params do
               required(:id).filled(:integer)
               optional(:phone).filled(:string)
+              optional(:password).filled(:string, min_size?: Constants::User::PASSWORD_MIN_LENGTH)
               optional(:username).filled(:string)
               optional(:role_ids).filled(:array)
               optional(:status).filled(:string, included_in?: %w[pending active inactive locked])

--- a/app/concepts/api/v1/users/accounts/operations/update.rb
+++ b/app/concepts/api/v1/users/accounts/operations/update.rb
@@ -17,6 +17,7 @@ module Api
             def params(input)
               @ctx = {}
               @params = to_snake_case(input[:params])
+              @input = input[:params]
             end
             def validate_schema
               @ctx['contract.default'] = Api::V1::Users::Accounts::Contracts::Update.kall(@params)
@@ -35,7 +36,11 @@ module Api
             end
 
             def update_user
-              unless @ctx[:model].update(@ctx['contract.default'].values.data)
+              attrs = @ctx['contract.default'].values.data
+              if @input['password']
+                attrs['password'] = @input[:password]
+              end
+              unless @ctx[:model].update(attrs)
                 return Failure({ ctx: @ctx, type: :invalid })
               end
 


### PR DESCRIPTION
The password parameter has been added to the API v1 update user account contract and operation. This change includes validating the password's minimum length and processing the password update within the attributes passed to the model's update function.