### PR TITLE
Add GetLastParams endpoint with index operations

### DIFF
--- a/app/concepts/api/v1/get_last_params/contracts/index.rb
+++ b/app/concepts/api/v1/get_last_params/contracts/index.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module GetLastParams
+      module Contracts
+        class Index < Dry::Validation::Contract
+          def self.kall(...)
+            new.call(...)
+          end
+          params do
+            optional(:name).maybe(:string, included_in?: Constants::VisitParams::RESOURCES)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/get_last_params/operations/index.rb
+++ b/app/concepts/api/v1/get_last_params/operations/index.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module GetLastParams
+      module Operations
+        class Index < ApplicationOperation
+          include Dry::Transaction
+
+          tee :params
+          step :validate_schema
+          step :list
+
+          def params(input)
+            @ctx = {}
+            @params = to_snake_case(input[:params])
+          end
+
+          def validate_schema
+            @ctx['contract.default'] = Api::V1::GetLastParams::Contracts::Index.kall(@params)
+            is_valid = @ctx['contract.default'].success?
+            return Success({ ctx: @ctx, type: :success }) if is_valid
+
+            Failure({ ctx: @ctx, type: :invalid }) unless is_valid
+          end
+
+          def list
+            @ctx[:data] = Api::V1::GetLastParams::Queries::Index.call(@ctx['contract.default']['name'])
+            Success({ ctx: @ctx, type: :success })
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/get_last_params/queries/index.rb
+++ b/app/concepts/api/v1/get_last_params/queries/index.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module GetLastParams
+      module Queries
+        class Index
+
+          VersionParamStruct = Struct.new(:id, :version, :resource_name, :resource_data)
+
+          include Api::V1::Lib::Queries::QueryHelper
+
+          def initialize(filter)
+            @model = VisitParamVersion
+            @filter = filter
+          end
+
+          def self.call(...)
+            new(...).call
+          end
+
+          def call
+            visit_param_versions = @model.all unless @filter
+            visit_param_versions = @model.where(name: @filter) if @filter
+            create_data_hash(visit_param_versions)
+          end
+
+          private
+
+          def create_data_hash(visit_param_versions, ignored_columns= %w[created_at discarded_at])
+            visit_param_versions.map do |param_version|
+              model = get_model(param_version)
+              allowed_columns = get_allowed_columns(model, ignored_columns)
+              data = get_data(model, allowed_columns)
+              create_version_param(param_version, data)
+            end
+          end
+
+          def get_model(param_version)
+            param_version.name.classify.constantize
+          end
+
+          def get_allowed_columns(model, ignored_columns)
+            model.column_names - ignored_columns
+          end
+
+          def get_data(model, allowed_columns)
+            model.kept.pluck(*allowed_columns).map { |record| allowed_columns.zip(record).to_h }
+          end
+
+          def create_version_param(param_version, data)
+            VersionParamStruct.new(param_version.id, param_version.version, param_version.name, data)
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/get_last_params/serializers/index.rb
+++ b/app/concepts/api/v1/get_last_params/serializers/index.rb
@@ -1,0 +1,20 @@
+
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module GetLastParams
+      module Serializers
+        class Index
+          include Alba::Resource
+          transform_keys :lower_camel
+
+
+
+          attributes :id, :version, :resource_name, :resource_data
+
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/get_last_params_controller.rb
+++ b/app/controllers/api/v1/get_last_params_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class GetLastParamsController < ApiController
+      def index
+        endpoint operation: Api::V1::GetLastParams::Operations::Index,
+                 renderer_options: { serializer: Api::V1::GetLastParams::Serializers::Index },
+                 options: { current_user: }
+      end
+
+    end
+  end
+end

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -1,6 +1,6 @@
 # == Schema Information
 #
-# Table name: place
+# Table name: places
 #
 #  id           :bigint           not null, primary key
 #  discarded_at :datetime

--- a/app/models/visit_param_version.rb
+++ b/app/models/visit_param_version.rb
@@ -1,0 +1,12 @@
+# == Schema Information
+#
+# Table name: visit_param_versions
+#
+#  id         :bigint           not null, primary key
+#  name       :string
+#  version    :integer          default(1)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+class VisitParamVersion < ApplicationRecord
+end

--- a/app/models/water_source_type.rb
+++ b/app/models/water_source_type.rb
@@ -1,6 +1,6 @@
 # == Schema Information
 #
-# Table name: elimination_method_types
+# Table name: water_source_types
 #
 #  id           :bigint           not null, primary key
 #  discarded_at :datetime

--- a/config/initializers/constants/visit_params.rb
+++ b/config/initializers/constants/visit_params.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Constants
+  module VisitParams
+    RESOURCES = %w[breeding_site_types container_types elimination_method_types water_source_types places].freeze
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,6 +63,8 @@ Rails.application.routes.draw do
           end
         end
       end
+
+      get 'get_last_params', controller: 'get_last_params', action: 'index'
     end
   end
 

--- a/db/migrate/20240725061011_create_visit_param_versions.rb
+++ b/db/migrate/20240725061011_create_visit_param_versions.rb
@@ -1,0 +1,10 @@
+class CreateVisitParamVersions < ActiveRecord::Migration[7.1]
+  def change
+    create_table :visit_param_versions do |t|
+      t.string :name
+      t.integer :version, default: 1
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240725080730_remove_category_from_places.rb
+++ b/db/migrate/20240725080730_remove_category_from_places.rb
@@ -1,0 +1,5 @@
+class RemoveCategoryFromPlaces < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :places, :category
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_25_035902) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_25_080730) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -87,6 +87,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_25_035902) do
     t.index ["name"], name: "index_countries_on_name"
   end
 
+  create_table "create_visit_param_versions", force: :cascade do |t|
+    t.string "name"
+    t.integer "version", default: 1
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "elimination_method_types", force: :cascade do |t|
     t.string "name"
     t.datetime "discarded_at"
@@ -127,7 +134,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_25_035902) do
 
   create_table "places", force: :cascade do |t|
     t.string "name"
-    t.string "category"
     t.datetime "discarded_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -247,6 +253,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_25_035902) do
     t.datetime "created_at"
     t.text "object_changes"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
+  end
+
+  create_table "visit_param_versions", force: :cascade do |t|
+    t.string "name"
+    t.integer "version", default: 1
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "water_source_types", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -127,7 +127,7 @@ end
 unless SeedTask.find_by(task_name: 'permissions')
   actions = %w[index show new create edit update destroy]
   resources = %w[teams organizations users roles permissions countries cities states neighborhoods ]
-  resources.product(actions).each{| resource, action| Permission.create(name: action, resource: resource) }
+  resources.product(actions).each { | resource, action| Permission.create(name: action, resource: resource) }
   SeedTask.create(task_name: 'permissions') if Permission.count == 63
 end
 
@@ -141,7 +141,7 @@ unless SeedTask.find_by(task_name: 'assign permissions')
   end
   admin_role.save!
 
-  SeedTask.create(task_name: 'permissions')
+  SeedTask.create(task_name: 'assign permissions')
 
 end
 
@@ -213,4 +213,12 @@ end
 unless SeedTask.find_by(task_name: 'create_places')
   Place.create([{ name: 'Cementerio' }, { name: 'Plaza' }])
   SeedTask.create(task_name: 'create_places')
+end
+
+
+#create default versions params
+unless SeedTask.find_by(task_name: 'create_visit_params')
+  data = Constants::VisitParams::RESOURCES
+  data.each { |value_params| VisitParamVersion.find_or_create_by(name: value_params) }
+  SeedTask.create(task_name: 'create_visit_params')
 end


### PR DESCRIPTION
Add GetLastParams endpoint with index operations

Implemented the GetLastParams endpoint in the API, including creation of Contracts, Operations, Queries, and Serializers for handling visit parameter versions. Added related database migrations, including the creation of the visit_param_versions table and removal of the category column from the places table.