### PR TITLE
Update seeds and serializers for permissions and blank checks

### DIFF
--- a/app/concepts/api/v1/users/accounts/serializers/show_current_user.rb
+++ b/app/concepts/api/v1/users/accounts/serializers/show_current_user.rb
@@ -14,11 +14,15 @@ module Api
             has_one :user_profile, record_type: :user_profile, serializer: Api::V1::Users::Accounts::Serializers::UserProfile
 
             attribute :roles do |user_account|
+              next unless user_account.roles.any?
+
               user_account.roles.map { |rol| rol.name }
             end
 
             attribute :permissions do |user_account|
-              user_account.permissions.map { |permission| "#{permission.resource}_#{permission.name}" }
+              next unless user_account.permissions.any?
+
+              user_account.permissions.map { |permission| "#{permission.resource}-#{permission.name}" }
             end
 
           end

--- a/app/concepts/api/v1/users/accounts/serializers/user_profile.rb
+++ b/app/concepts/api/v1/users/accounts/serializers/user_profile.rb
@@ -12,18 +12,26 @@ module Api
                        :points, :email
 
             attribute :city do |user_profile|
+              next if user_profile.city.nil?
+
               user_profile.city.name
             end
 
             attribute :neighborhood do |user_profile|
+              next if user_profile.neighborhood.nil?
+
               user_profile.neighborhood&.name
             end
 
             attribute :organization do |user_profile|
+              next if user_profile.organization.nil?
+
               user_profile.organization&.name
             end
 
             attribute :team do |user_profile|
+              next if user_profile.team.nil?
+
               user_profile.team&.name
             end
 

--- a/app/concepts/api/v1/users/sessions/serializers/create.rb
+++ b/app/concepts/api/v1/users/sessions/serializers/create.rb
@@ -22,7 +22,7 @@ module Api
             end
 
             attribute :permissions do |user_account|
-              user_account.permissions.map { |permission| "#{permission.resource}_#{permission.name}" }
+              user_account.permissions.map { |permission| "#{permission.resource}-#{permission.name}" }
             end
 
             attribute :state do |user_account|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -125,7 +125,7 @@ end
 
 #permissions
 unless SeedTask.find_by(task_name: 'permissions')
-  actions = %w[index show new create edit update destroy]
+  actions = %w[index show create edit update destroy]
   resources = %w[teams organizations users roles permissions countries cities states neighborhoods ]
   resources.product(actions).each { | resource, action| Permission.create(name: action, resource: resource) }
   SeedTask.create(task_name: 'permissions') if Permission.count == 63
@@ -237,4 +237,13 @@ unless SeedTask.find_by(task_name: 'create_special_places')
   SpecialPlace.create(name: 'Cementerio')
   SpecialPlace.create(name: 'Colegio')
   SeedTask.create(task_name: 'create_special_places')
+end
+
+unless SeedTask.find_by(task_name: 'create_authorize_user_permission_task')
+  confirm_account = Permission.create(name: 'users_confirm_account', resource: 'users')
+  rol_admin = Role.find_by_name('admin')
+  rol_admin.permissions << confirm_account
+  rol_admin.save
+  SeedTask.create(task_name: 'create_authorize_user_permission_task')
+
 end


### PR DESCRIPTION
Removed 'new' action from seed permissions; added 'confirm_account' permission for admin role. Enhanced serializers to check for blank fields before accessing attributes and updated permission formatting to use hyphens.