### PR TITLE
Add roles attribute to user account serializer

### DIFF
--- a/app/concepts/api/v1/users/accounts/serializers/index.rb
+++ b/app/concepts/api/v1/users/accounts/serializers/index.rb
@@ -23,6 +23,15 @@ module Api
             attribute :created_at do |user|
               user.created_at.strftime('%Y-%m-%d')
             end
+
+            attribute :roles do |user|
+              user.roles.map do |role|
+                {
+                  id: role.id,
+                  name: role.name
+                }
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
This change introduces a new attribute, `roles`, to the user account serializer. The `roles` attribute includes the ID and name of each role associated with a user, enhancing the API response with more detailed user information.