### PR TITLE
Fix city creation error handling and add state ID validation

### DIFF
--- a/app/concepts/api/v1/cities/contracts/create.rb
+++ b/app/concepts/api/v1/cities/contracts/create.rb
@@ -25,6 +25,14 @@ module Api
               end
             end
           end
+
+          rule(:state_id) do
+            unless State.exists?(id: value)
+              key(:state_id).failure(text: "The state with id: #{value} does not exist",
+                                 predicate: :not_exists?)
+            end
+          end
+
         end
       end
     end

--- a/app/concepts/api/v1/cities/operations/create.rb
+++ b/app/concepts/api/v1/cities/operations/create.rb
@@ -29,7 +29,8 @@ module Api
             @ctx[:model] = City.create(@ctx['contract.default'].values.data)
             return Success({ ctx: @ctx, type: :created }) if @ctx[:model].persisted?
 
-            Failure({ ctx: @ctx, type: :invalid, model: true })
+            errors = ErrorFormater.new_error(field: :base, msg: @ctx[:model].errors.full_messages, custom_predicate: :not_found? )
+            Failure({ ctx: @ctx, type: :invalid, errors: })
           end
 
           def includes

--- a/app/concepts/api/v1/users/accounts/serializers/index.rb
+++ b/app/concepts/api/v1/users/accounts/serializers/index.rb
@@ -23,6 +23,15 @@ module Api
             attribute :created_at do |user|
               user.created_at.strftime('%Y-%m-%d')
             end
+
+            attribute :roles do |user|
+              user.roles.map do |role|
+                {
+                  id: role.id,
+                  name: role.name
+                }
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
Improve error handling by formatting detailed error messages when city creation fails. Also, add a validation rule to ensure the provided state ID exists within the database.