### PR TITLE
FIX error typo

### DIFF
--- a/app/concepts/api/v1/special_places/operations/index.rb
+++ b/app/concepts/api/v1/special_places/operations/index.rb
@@ -29,9 +29,9 @@ module Api
           end
 
           def cursor_and_paginate
-            @ctx[:sort] = { field: 'special_place.name', direction: 'asc' } if @params['sort'].nil?
+            @ctx[:sort] = { field: 'special_places.name', direction: 'asc' } if @params['sort'].nil?
             direction = @params['order'].nil? ? 'asc' : @params['order']
-            @ctx[:sort] = {field: @params['sort'], direction: } if @params['sort']
+            @ctx[:sort] = { field: @params['sort'], direction: } if @params['sort']
           end
 
           def list


### PR DESCRIPTION
Corrected the key from 'special_place.name' to 'special_places.name' in the default sorting logic. This ensures consistency with the expected parameter naming convention.