### PR TITLE
Fix/enable token and permissions controls

### DIFF
--- a/app/concepts/api/v1/cities/contracts/update.rb
+++ b/app/concepts/api/v1/cities/contracts/update.rb
@@ -12,17 +12,13 @@ module Api
           params do
             required(:id).filled(:integer)
             optional(:name).filled(:string)
-            optional(:neighborhoods_attributes).array(:hash) do
-              optional(:id).filled(:integer)
-              optional(:name).filled(:string)
-              optional(:_destroy).filled(:integer)
-            end
+            optional(:neighborhoods_attributes).filled(:array)
           end
 
           rule(:neighborhoods_attributes).each do
-            if value[:name] && Neighborhood.exists?(name: value[:name].downcase, discarded_at: nil)
+            if values[:neighborhoods_attributes] && Neighborhood.exists?(name: value[:name].downcase, discarded_at: nil)
               key.failure('Neighborhood already exists in this neighborhood')
-            end
+             end
           end
 
         end

--- a/app/concepts/api/v1/cities/operations/update.rb
+++ b/app/concepts/api/v1/cities/operations/update.rb
@@ -19,7 +19,7 @@ module Api
           end
 
           def validate_schema
-            @ctx['contract.default'] = Api::V1::Cities::Contracts::Update.kall(@params)
+            @ctx['contract.default'] = Api::V1::Cities::Contracts::Update.kall(@params.to_h)
             is_valid = @ctx['contract.default'].success?
             return Success({ ctx: @ctx, type: :success }) if is_valid
 
@@ -31,9 +31,9 @@ module Api
               City.kept.find_by(id: @params[:id], state_id: @params[:state_id], country_id: @params[:country_id])
             return Success({ ctx: @ctx, type: :success }) if @ctx[:model]
 
-            ErrorFormater.new_error(@ctx['contract.default'].errors,nil, I18n.t('errors.users.not_found'),
-                                    custom_predicate: :not_found?)
-            Failure({ ctx: @ctx, type: :invalid, model: true }) unless @ctx[:model]
+            errors = ErrorFormater.new_error(field: :base, msg: @ctx['contract.default'].errors,
+                                             custom_predicate: :not_found? )
+            Failure({ ctx: @ctx, type: :invalid, errors:  }) unless @ctx[:model]
           end
 
           def update_neighborhoods
@@ -46,12 +46,14 @@ module Api
             ActiveRecord::Base.transaction do
               begin
                 data = @ctx['contract.default'].values.data
-                data[:neighborhoods_attributes].map do |obj_hash|
-                  obj_hash[:state_id] = @ctx[:model].state_id
-                  obj_hash[:country_id] = @ctx[:model].country_id
+                if @ctx['contract.default'].values.data[:neighborhoods_attributes]
+                  data[:neighborhoods_attributes].map do |obj_hash|
+                    obj_hash[:state_id] = @ctx[:model].state_id
+                    obj_hash[:country_id] = @ctx[:model].country_id
+                  end
                 end
                 @ctx[:model].update!(data)
-                update_neighborhoods
+                update_neighborhoods  if @ctx['contract.default'].values.data[:neighborhoods_attributes]
                 Success({ ctx: @ctx, type: :success })
               rescue ActiveRecord::RecordInvalid => invalid
                 errors = ErrorFormater.new_error(field: :base, msg: @ctx[:model].errors.full_messages,

--- a/app/controllers/api/v1/admin/users_controller.rb
+++ b/app/controllers/api/v1/admin/users_controller.rb
@@ -7,7 +7,8 @@ module Api
 
         def change_status
           endpoint operation: Api::V1::Users::Accounts::Operations::ChangeStatus,
-                   renderer_options: { serializer: Api::V1::Users::Accounts::Serializers::UserAccount }
+                   renderer_options: { serializer: Api::V1::Users::Accounts::Serializers::UserAccount },
+                   options: { current_user: }
         end
       end
     end

--- a/app/controllers/api/v1/get_last_params_controller.rb
+++ b/app/controllers/api/v1/get_last_params_controller.rb
@@ -2,7 +2,7 @@
 
 module Api
   module V1
-    class GetLastParamsController < ApiController
+    class GetLastParamsController < AuthorizedApiController
       def index
         endpoint operation: Api::V1::GetLastParams::Operations::Index,
                  renderer_options: { serializer: Api::V1::GetLastParams::Serializers::Index },

--- a/app/controllers/api/v1/locations_controller.rb
+++ b/app/controllers/api/v1/locations_controller.rb
@@ -2,7 +2,7 @@
 
 module Api
   module V1
-    class LocationsController < ApiController
+    class LocationsController < AuthorizedApiController
       def index
         endpoint operation: Api::V1::Locations::Operations::Index,
                  renderer_options: { serializer: Api::V1::Locations::Serializers::IndexSerializer },

--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -5,12 +5,14 @@ module Api
     class OrganizationsController < AuthorizedApiController
       def index
         endpoint operation: Api::V1::Organizations::Operations::Index,
-                 renderer_options: { serializer: Api::V1::Organizations::Serializers::Index }
+                 renderer_options: { serializer: Api::V1::Organizations::Serializers::Index },
+                 options: { current_user: }
       end
 
       def show
         endpoint operation: Api::V1::Organizations::Operations::Show,
-                 renderer_options: { serializer: Api::V1::Organizations::Serializers::Index }
+                 renderer_options: { serializer: Api::V1::Organizations::Serializers::Index },
+                 options: { current_user: }
       end
 
       def create

--- a/app/controllers/api/v1/permissions_controller.rb
+++ b/app/controllers/api/v1/permissions_controller.rb
@@ -2,20 +2,22 @@
 
 module Api
   module V1
-    class PermissionsController < ApiController
+    class PermissionsController < AuthorizedApiController
 
       def index
         endpoint operation: Api::V1::Permissions::Operations::Index,
                  renderer_options: {
                    serializer: Api::V1::Permissions::Serializers::Index
-                 }
+                 },
+                 options: { current_user: }
       end
 
       def show
         endpoint operation: Api::V1::Permissions::Operations::Show,
                  renderer_options: {
                    serializer: Api::V1::Permissions::Serializers::Show
-                 }
+                 },
+                 options: { current_user: }
       end
 
     end

--- a/app/controllers/api/v1/roles_controller.rb
+++ b/app/controllers/api/v1/roles_controller.rb
@@ -2,27 +2,30 @@
 
 module Api
   module V1
-    class RolesController < ApiController
+    class RolesController < AuthorizedApiController
 
       def index
         endpoint operation: Api::V1::Roles::Operations::Index,
                  renderer_options: {
                    serializer: Api::V1::Roles::Serializers::Index
-                 }
+                 },
+                 options: { current_user: }
       end
 
       def create
         endpoint operation: Api::V1::Roles::Operations::Create,
                  renderer_options: {
                    serializer: Api::V1::Roles::Serializers::Create
-                 }
+                 },
+                 options: { current_user: }
       end
 
       def update
         endpoint operation: Api::V1::Roles::Operations::Update,
                  renderer_options: {
                    serializer: Api::V1::Roles::Serializers::Update
-                 }
+                 },
+                 options: { current_user: }
       end
 
     end

--- a/app/controllers/api/v1/special_places_controller.rb
+++ b/app/controllers/api/v1/special_places_controller.rb
@@ -5,12 +5,14 @@ module Api
     class SpecialPlacesController < AuthorizedApiController
       def index
         endpoint operation: Api::V1::SpecialPlaces::Operations::Index,
-                 renderer_options: { serializer: Api::V1::SpecialPlaces::Serializers::Index }
+                 renderer_options: { serializer: Api::V1::SpecialPlaces::Serializers::Index },
+                 options: { current_user: }
       end
 
       def show
         endpoint operation: Api::V1::SpecialPlaces::Operations::Show,
-                 renderer_options: { serializer: Api::V1::SpecialPlaces::Serializers::Index }
+                 renderer_options: { serializer: Api::V1::SpecialPlaces::Serializers::Index },
+                 options: { current_user: }
       end
 
       def create

--- a/app/controllers/api/v1/users/accounts_controller.rb
+++ b/app/controllers/api/v1/users/accounts_controller.rb
@@ -12,7 +12,8 @@ module Api
 
         def confirm_account
           endpoint operation: Api::V1::Users::Accounts::Operations::Confirm,
-                   renderer_options: { serializer: Api::V1::Users::Accounts::Serializers::UserAccount }
+                   renderer_options: { serializer: Api::V1::Users::Accounts::Serializers::UserAccount },
+                   options: { current_user: }
         end
       end
     end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -8,19 +8,22 @@ module Api
         endpoint operation: Api::V1::Users::Accounts::Operations::Index,
                  renderer_options: {
                    serializer: Api::V1::Users::Accounts::Serializers::Index
-                 }
+                 },
+                 options: { current_user: }
       end
 
       def show
         endpoint operation: Api::V1::Users::Accounts::Operations::Show,
-                 renderer_options: { serializer: Api::V1::Users::Accounts::Serializers::Show }
+                 renderer_options: { serializer: Api::V1::Users::Accounts::Serializers::Show },
+                 options: { current_user: }
       end
 
       def update
         endpoint operation: Api::V1::Users::Accounts::Operations::Update,
                  renderer_options: {
                    serializer: Api::V1::Users::Accounts::Serializers::ShowCurrentUser
-                 }
+                 },
+                 options: { current_user: }
       end
 
       def show_current_user

--- a/app/controllers/authorized_api_controller.rb
+++ b/app/controllers/authorized_api_controller.rb
@@ -5,8 +5,8 @@ require 'dry/transaction'
 class AuthorizedApiController < ApiController
   include Dry::Transaction
 
-  # before_action :authorize_access_request!
-  # before_action :check_permissions!
+  before_action :authorize_access_request!
+  before_action :check_permissions!
 
   def self.call(*args)
     new.call(*args)

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -39,7 +39,7 @@ module Authentication
     return false unless current_user
 
     unless current_user.can?(action_name, controller_name)
-      exception_response(I18n.t('errors.unauthorized'), :unauthorized,"#{controller_name}_#{action_name}")
+      exception_response(I18n.t('errors.unauthorized'), :unauthorized,"#{controller_name}-#{action_name}")
     end
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -247,3 +247,17 @@ unless SeedTask.find_by(task_name: 'create_authorize_user_permission_task')
   SeedTask.create(task_name: 'create_authorize_user_permission_task')
 
 end
+
+
+unless SeedTask.find_by(task_name: 'create_locations_special_places_permissions')
+  locations_index = Permission.create(resource: 'locations', name: 'index')
+  special_places_index = Permission.create(resource: 'special_places', name: 'index')
+  special_places_create = Permission.create(resource: 'special_places', name: 'create')
+  special_places_update = Permission.create(resource: 'special_places', name: 'update')
+  special_places_destroy = Permission.create(resource: 'special_places', name: 'destroy')
+  rol_admin = Role.find_by_name('admin')
+  rol_admin.permissions << [locations_index, special_places_create, special_places_destroy, special_places_index, special_places_update]
+  rol_admin.save
+  SeedTask.create(task_name: 'create_locations_special_places_permissions')
+
+end


### PR DESCRIPTION
Update controllers to inherit from AuthorizedApiController

Controllers now inherit from AuthorizedApiController instead of ApiController to ensure authentication. Additionally, passed current_user as an option to renderer_options in applicable endpoints for user-specific processing. Updated seeds to include permissions for special places and locations.