### PR TITLE
Add country attribute to user session serializer

### DIFF
--- a/app/concepts/api/v1/users/sessions/serializers/create.rb
+++ b/app/concepts/api/v1/users/sessions/serializers/create.rb
@@ -25,6 +25,17 @@ module Api
               user_account.permissions.map { |permission| "#{permission.resource}-#{permission.name}" }
             end
 
+            attribute :country do |user_account|
+              city = user_account.user_profile.city
+              next unless city
+              next unless city&.country
+
+              {
+                id: city.country.id,
+                name: city.country.name
+              }
+            end
+
             attribute :state do |user_account|
               next unless user_account.user_profile.city
 


### PR DESCRIPTION
This commit adds a new `country` attribute to the user session serializer to include country details based on the user's city information. The country attribute will contain the country’s ID and name, assuming city data is present and valid. This enhancement aids