### PR TITLE
Add House and HouseBlock models with migrations

### DIFF
--- a/app/concepts/api/v1/users/sessions/serializers/create.rb
+++ b/app/concepts/api/v1/users/sessions/serializers/create.rb
@@ -25,6 +25,17 @@ module Api
               user_account.permissions.map { |permission| "#{permission.resource}-#{permission.name}" }
             end
 
+            attribute :country do |user_account|
+              city = user_account.user_profile.city
+              next unless city
+              next unless city&.country
+
+              {
+                id: city.country.id,
+                name: city.country.name
+              }
+            end
+
             attribute :state do |user_account|
               next unless user_account.user_profile.city
 

--- a/app/models/house.rb
+++ b/app/models/house.rb
@@ -1,0 +1,56 @@
+# == Schema Information
+#
+# Table name: houses
+#
+#  id               :bigint           not null, primary key
+#  address          :string
+#  container_count  :integer
+#  discarded_at     :datetime
+#  house_type       :string
+#  latitude         :float
+#  longitude        :float
+#  notes            :string
+#  reference_code   :string
+#  status           :string
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  city_id          :bigint           not null
+#  country_id       :bigint           not null
+#  house_block_id   :bigint
+#  neighborhood_id  :bigint           not null
+#  special_place_id :bigint
+#  state_id         :bigint           not null
+#  team_id          :bigint
+#  user_profile_id  :bigint           not null
+#  wedge_id         :bigint           not null
+#
+# Indexes
+#
+#  index_houses_on_city_id           (city_id)
+#  index_houses_on_country_id        (country_id)
+#  index_houses_on_house_block_id    (house_block_id)
+#  index_houses_on_neighborhood_id   (neighborhood_id)
+#  index_houses_on_special_place_id  (special_place_id)
+#  index_houses_on_state_id          (state_id)
+#  index_houses_on_team_id           (team_id)
+#  index_houses_on_user_profile_id   (user_profile_id)
+#  index_houses_on_wedge_id          (wedge_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (city_id => cities.id)
+#  fk_rails_...  (country_id => countries.id)
+#  fk_rails_...  (house_block_id => house_blocks.id)
+#  fk_rails_...  (neighborhood_id => neighborhoods.id)
+#  fk_rails_...  (special_place_id => special_places.id)
+#  fk_rails_...  (state_id => states.id)
+#  fk_rails_...  (team_id => teams.id)
+#  fk_rails_...  (user_profile_id => user_profiles.id)
+#  fk_rails_...  (wedge_id => wedges.id)
+#
+class House < ApplicationRecord
+  belongs_to :house_block
+  belongs_to :sector
+  belongs_to :wedge
+  belongs_to :special_place
+end

--- a/app/models/house_block.rb
+++ b/app/models/house_block.rb
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: house_blocks
+#
+#  id              :bigint           not null, primary key
+#  discarded_at    :datetime
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  team_id         :bigint           not null
+#  user_profile_id :bigint           not null
+#
+# Indexes
+#
+#  index_house_blocks_on_team_id          (team_id)
+#  index_house_blocks_on_user_profile_id  (user_profile_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (team_id => teams.id)
+#  fk_rails_...  (user_profile_id => user_profiles.id)
+#
+class HouseBlock < ApplicationRecord
+  has_many :houses, dependent: :nullify
+  belongs_to :team
+  belongs_to :created_by, class_name: 'UserProfile'
+end

--- a/db/migrate/20240807071033_create_house_blocks.rb
+++ b/db/migrate/20240807071033_create_house_blocks.rb
@@ -1,0 +1,10 @@
+class CreateHouseBlocks < ActiveRecord::Migration[7.1]
+  def change
+    create_table :house_blocks do |t|
+      t.datetime :discarded_at
+      t.references :team, null: false, foreign_key: true
+      t.references :user_profile, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240807181557_create_houses.rb
+++ b/db/migrate/20240807181557_create_houses.rb
@@ -1,0 +1,26 @@
+class CreateHouses < ActiveRecord::Migration[7.1]
+  def change
+    create_table :houses do |t|
+      t.references :country, null: false, foreign_key: true
+      t.references :state, null: false, foreign_key: true
+      t.references :city, null: false, foreign_key: true
+      t.references :neighborhood, null: false, foreign_key: true
+      t.references :wedge, null: false, foreign_key: true
+      t.references :house_block, null: true, foreign_key: true
+      t.references :special_place, null: true, foreign_key: true
+      t.references :team, null: true, foreign_key: true
+      t.references :user_profile, null: false, foreign_key: true
+      t.datetime :discarded_at
+      t.string :reference_code
+      t.string :house_type
+      t.string :address
+      t.float :latitude
+      t.float :longitude
+      t.string :notes
+      t.string :status
+      t.integer :container_count
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_30_140540) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_07_181557) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -99,6 +99,48 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_30_140540) do
     t.datetime "discarded_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "house_blocks", force: :cascade do |t|
+    t.datetime "discarded_at"
+    t.bigint "team_id", null: false
+    t.bigint "user_profile_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["team_id"], name: "index_house_blocks_on_team_id"
+    t.index ["user_profile_id"], name: "index_house_blocks_on_user_profile_id"
+  end
+
+  create_table "houses", force: :cascade do |t|
+    t.bigint "country_id", null: false
+    t.bigint "state_id", null: false
+    t.bigint "city_id", null: false
+    t.bigint "neighborhood_id", null: false
+    t.bigint "wedge_id", null: false
+    t.bigint "house_block_id"
+    t.bigint "special_place_id"
+    t.bigint "team_id"
+    t.bigint "user_profile_id", null: false
+    t.datetime "discarded_at"
+    t.string "reference_code"
+    t.string "house_type"
+    t.string "address"
+    t.float "latitude"
+    t.float "longitude"
+    t.string "notes"
+    t.string "status"
+    t.integer "container_count"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["city_id"], name: "index_houses_on_city_id"
+    t.index ["country_id"], name: "index_houses_on_country_id"
+    t.index ["house_block_id"], name: "index_houses_on_house_block_id"
+    t.index ["neighborhood_id"], name: "index_houses_on_neighborhood_id"
+    t.index ["special_place_id"], name: "index_houses_on_special_place_id"
+    t.index ["state_id"], name: "index_houses_on_state_id"
+    t.index ["team_id"], name: "index_houses_on_team_id"
+    t.index ["user_profile_id"], name: "index_houses_on_user_profile_id"
+    t.index ["wedge_id"], name: "index_houses_on_wedge_id"
   end
 
   create_table "neighborhoods", force: :cascade do |t|
@@ -287,6 +329,17 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_30_140540) do
   add_foreign_key "cities", "countries"
   add_foreign_key "cities", "states"
   add_foreign_key "container_types", "breeding_site_types"
+  add_foreign_key "house_blocks", "teams"
+  add_foreign_key "house_blocks", "user_profiles"
+  add_foreign_key "houses", "cities"
+  add_foreign_key "houses", "countries"
+  add_foreign_key "houses", "house_blocks"
+  add_foreign_key "houses", "neighborhoods"
+  add_foreign_key "houses", "special_places"
+  add_foreign_key "houses", "states"
+  add_foreign_key "houses", "teams"
+  add_foreign_key "houses", "user_profiles"
+  add_foreign_key "houses", "wedges"
   add_foreign_key "neighborhoods", "cities"
   add_foreign_key "neighborhoods", "countries"
   add_foreign_key "neighborhoods", "states"


### PR DESCRIPTION
Introduced new models, House and HouseBlock, alongside their respective database migrations. The House model includes multiple references to other entities, while HouseBlock has associations with houses, teams, and user profiles. This update also includes schema changes to integrate these models and their relationships into the database.