### PR TITLE
Refactor team member terminology

### DIFF
--- a/app/concepts/api/v1/teams/contracts/create.rb
+++ b/app/concepts/api/v1/teams/contracts/create.rb
@@ -12,19 +12,19 @@ module Api
             required(:name).filled(:string)
             required(:organization_id).filled(:integer)
             required(:leader_id).filled(:integer)
-            required(:user_profile_ids).filled(:array).each(:integer)
+            required(:member_ids).filled(:array).each(:integer)
             required(:sector_id).filled(:integer)
             required(:wedge_id).filled(:integer)
           end
 
-          rule(:user_profile_ids).each do
-            if values[:user_profile_ids] && !UserProfile.exists?(id: values[:user_profile_ids])
-              key(:user_profile_ids).failure(text: 'user_profile does not exist', predicate: :not_found?)
+          rule(:member_ids).each do
+            if values[:member_ids] && !UserProfile.exists?(id: values[:member_ids])
+              key(:member_ids).failure(text: 'member (user) does not exist', predicate: :not_found?)
             end
 
-            if values[:user_profile_ids] &&
-               UserProfile.where(id: values[:user_profile_ids], team_id: nil).count != values[:user_profile_ids].count
-              key(:user_profile_ids).failure(text: "user_profile with id: '#{value}' is already assigned to a brigade", predicate: :unique?)
+            if values[:member_ids] &&
+               UserProfile.where(id: values[:member_ids], team_id: nil).count != values[:member_ids].count
+              key(:member_ids).failure(text: "user_profile with id: '#{value}' is already assigned to a brigade", predicate: :unique?)
             end
 
           end

--- a/app/concepts/api/v1/teams/contracts/update.rb
+++ b/app/concepts/api/v1/teams/contracts/update.rb
@@ -14,19 +14,19 @@ module Api
             optional(:name).filled(:string)
             optional(:organization_id).filled(:integer)
             optional(:leader_id).maybe(:integer)
-            optional(:user_profile_ids).maybe(:array).each(:integer)
+            optional(:member_ids).maybe(:array).each(:integer)
             optional(:sector_id).filled(:integer)
             optional(:wedge_id).filled(:integer)
           end
 
-          rule(:user_profile_ids).each do
-            if values[:user_profile_ids] && !UserProfile.exists?(id: values[:user_profile_ids])
-              key(:user_profile_ids).failure(text: 'user_profile does not exist', predicate: :not_found?)
+          rule(:member_ids).each do
+            if values[:member_ids] && !UserProfile.exists?(id: values[:member_ids])
+              key(:member_ids).failure(text: 'user_profile does not exist', predicate: :not_found?)
             end
 
-            if values[:user_profile_ids] &&
-              UserProfile.where(id: values[:user_profile_ids], team_id: nil).count != values[:user_profile_ids].count
-              key(:user_profile_ids).failure(text: "user_profile with id: '#{value}' is already assigned to a brigade", predicate: :unique?)
+            if values[:member_ids] &&
+              UserProfile.where(id: values[:member_ids], team_id: nil).count != values[:member_ids].count
+              key(:member_ids).failure(text: "user_profile with id: '#{value}' is already assigned to a brigade", predicate: :unique?)
             end
 
           end

--- a/app/concepts/api/v1/teams/serializers/index.rb
+++ b/app/concepts/api/v1/teams/serializers/index.rb
@@ -15,7 +15,7 @@ module Api
             "#{brigade.leader.first_name}, #{brigade.leader.last_name}"
           end
 
-          attribute :user_profiles do |brigade|
+          attribute :members do |brigade|
             brigade.members.map { |user| "#{user.first_name}, #{user.last_name}"  }
           end
 

--- a/config/initializers/constants/permission_codes.rb
+++ b/config/initializers/constants/permission_codes.rb
@@ -61,7 +61,8 @@ module Constants
       cities_index: :cities_index,
       cities_show: :cities_show,
       cities_destroy: :cities_destroy,
-      house_blocks: :house_blocks_index
+      house_blocks: :house_blocks_index,
+      users_change_status: :users_change_status
     }.freeze
   end
 end


### PR DESCRIPTION
Updated variable names and attributes to use "member" instead of "user_profile" for consistency across serializers and contracts. Additionally, added a new permission code for changing user status.