### PR TITLE
Develop

### DIFF
--- a/app/concepts/api/v1/teams/contracts/update.rb
+++ b/app/concepts/api/v1/teams/contracts/update.rb
@@ -57,7 +57,7 @@ module Api
           end
 
           rule(:name) do
-            if values[:name] && Team.exists?(name: values[:name].downcase)
+            if values[:name] && Team.where.not(id: values[:id]).exists?(name: values[:name].downcase)
               key(:name).failure(text: 'the team name is already in use', predicate: :unique?)
             end
           end

--- a/app/concepts/api/v1/teams/contracts/update.rb
+++ b/app/concepts/api/v1/teams/contracts/update.rb
@@ -24,10 +24,6 @@ module Api
               key(:member_ids).failure(text: 'user_profile does not exist', predicate: :not_found?)
             end
 
-            if values[:member_ids] &&
-              UserProfile.where(id: values[:member_ids], team_id: nil).count != values[:member_ids].count
-              key(:member_ids).failure(text: "user_profile with id: '#{value}' is already assigned to a brigade", predicate: :unique?)
-            end
 
           end
 


### PR DESCRIPTION
Previously, the validation only checked if the name existed in the database, which caused issues during updates. Now, it excludes the current team's ID from the check, allowing teams to update without unnecessary uniqueness conflicts.