### PR TITLE
Fix seed permissions assignment and update JSON keys

### DIFF
--- a/app/concepts/api/v1/questionnaires/serializers/show.rb
+++ b/app/concepts/api/v1/questionnaires/serializers/show.rb
@@ -26,7 +26,7 @@ module Api
               {
                 id: question.id,
                 question: question.question,
-                type_field: question.type_field,
+                typeField: question.type_field,
                 next: question.next,
                 image: get_image_obj.call(question),
                 options: question.options.map do |option|
@@ -35,7 +35,8 @@ module Api
                     name: option.name,
                     required: option.required,
                     textArea: option.text_area,
-                    image: get_image_obj.call(option)
+                    image: get_image_obj.call(option),
+                    next: option.next
                   }
                 end
               }

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -399,7 +399,7 @@ unless SeedTask.find_by(task_name: 'create_visit_and_list_house_permissions')
   permissions_array = []
 
   permissions.each do |permission|
-    permissions_array = Permission.create(permission)
+    permissions_array << Permission.create(permission)
   end
   role = Role.first
   role.permissions << permissions_array


### PR DESCRIPTION
Corrected the assignment of permissions in the seed file to use the shovel operator for array accumulation. Also modified the JSON serializer to properly camelCase keys and added the 'next' field to the options.