### PR TITLE
Add filtering by reference code to house queries

### DIFF
--- a/app/concepts/api/v1/houses/contracts/index.rb
+++ b/app/concepts/api/v1/houses/contracts/index.rb
@@ -10,7 +10,7 @@ module Api
           end
           params do
             optional(:filter).maybe(:hash) do
-              optional(:reference_code).maybe(:integer)
+              optional(:reference_code).maybe(:string)
               optional(:house_block_id).maybe(:integer)
               optional(:country_id).maybe(:integer)
               optional(:state_id).maybe(:integer)

--- a/app/concepts/api/v1/houses/contracts/list_to_visit.rb
+++ b/app/concepts/api/v1/houses/contracts/list_to_visit.rb
@@ -9,6 +9,11 @@ module Api
             new.call(...)
           end
           params do
+
+            optional(:filter).maybe(:hash) do
+              optional(:reference_code).maybe(:string)
+            end
+
             optional(:page).maybe(:hash) do
               optional(:is_cursor).maybe(:bool)
             end

--- a/app/concepts/api/v1/houses/operations/list_to_visit.rb
+++ b/app/concepts/api/v1/houses/operations/list_to_visit.rb
@@ -36,7 +36,7 @@ module Api
           end
 
           def list
-            @ctx[:data] = Api::V1::Houses::Queries::ListToVisit.call(@user_account)
+            @ctx[:data] = Api::V1::Houses::Queries::ListToVisit.call(@user_account, @ctx['contract.default']['filter'])
             Success({ ctx: @ctx, type: :success })
           end
 

--- a/app/concepts/api/v1/houses/queries/list_to_visit.rb
+++ b/app/concepts/api/v1/houses/queries/list_to_visit.rb
@@ -7,9 +7,10 @@ module Api
         class ListToVisit
           include Api::V1::Lib::Queries::QueryHelper
 
-          def initialize(user_account)
+          def initialize(user_account, filter)
             @model = House
             @user_account = user_account
+            @filter = filter
           end
 
           def self.call(...)
@@ -18,16 +19,24 @@ module Api
 
           def call
             @model.yield_self(&method(:houses_by_user))
+                  .yield_self(&method(:reference_code_clause))
           end
 
           private
 
-          attr_reader :houses
+          attr_reader :houses, :filter
 
           def houses_by_user(relation)
             return relation (relation) if @user_account.nil?
 
             relation.where(house_block_id: @user_account.house_blocks.pluck(:id))
+          end
+
+          def reference_code_clause(relation)
+            return relation if @filter.nil? || @filter[:reference_code].blank?
+
+            relation.where('reference_code ilike :query', query: "%#{@filter[:reference_code]}%")
+
           end
         end
       end


### PR DESCRIPTION
Introduced a filter parameter to the ListToVisit query for houses, allowing searches using a reference code. Updated relevant contracts and operations to support the new filtering capability.