### PR TITLE
Remove team_id validation and update question descriptions

### DIFF
--- a/app/concepts/api/v1/questionnaires/serializers/show.rb
+++ b/app/concepts/api/v1/questionnaires/serializers/show.rb
@@ -27,6 +27,7 @@ module Api
                 id: question.id,
                 question: question.question,
                 typeField: question.type_field,
+                description: question.description,
                 next: question.next,
                 image: get_image_obj.call(question),
                 options: question.options.map do |option|

--- a/app/concepts/api/v1/visits/contracts/create.rb
+++ b/app/concepts/api/v1/visits/contracts/create.rb
@@ -34,13 +34,6 @@ module Api
             end
           end
 
-          rule(:team_id) do
-            unless Team.exists?(id: value)
-              key(:team_id).failure(text: "The Team with id: #{value} does not exist",
-                                    predicate: :not_exists?)
-            end
-          end
-
           rule(:questionnaire_id) do
             unless Questionnaire.kept.exists?(id: value)
               key(:team_id).failure(text: "The Questionnaire with id: #{value} does not exist",

--- a/db/files/questions.rb
+++ b/db/files/questions.rb
@@ -24,14 +24,14 @@ QUESTIONS_DATA = [
   {
     id: 2,
     question: "En la huerta",
-    description: "Vamos a buscar todos los recipientes que contienen agua y potencialmente son criaderos de zancudos.",
+    description: "Vamos a buscar todos los recipientes que contienen agua y potencialmente son criaderos de zancudos.\n\nIniciamos la revisión de la vivienda por la derecha y finalizamos por la izquierda.",
     type_field: "splash",
     next: 4
   },
   {
     id: 3,
     question: "En la casa",
-    description: "Vamos a buscar todos los recipientes que contienen agua y potencialmente son criaderos de zancudos.",
+    description: "Lleguemos a la casa con mucho respeto.\n\nEs importante que las personas nos sientan como alguien que les llega a apoyar para prevenir el dengue.\n\nPidamos permiso para pasar.\n\nNo lleguemos como inspectores, o para juzgar al hogar.",
     type_field: "splash",
     next: 5
   },


### PR DESCRIPTION
Removed unnecessary team_id existence validation rule from the visits create contract. Improved descriptions for certain questions in the db/files/questions.rb file to provide clearer guidance. Additionally, the questionnaires serializer now includes question descriptions.