### PR TITLE
Add change team functionality for user accounts

### DIFF
--- a/app/concepts/api/v1/house_blocks/serializers/index.rb
+++ b/app/concepts/api/v1/house_blocks/serializers/index.rb
@@ -19,6 +19,10 @@ module Api
             house_block.houses&.pluck(:id)&.compact
           end
 
+          attribute :in_use do |house_block|
+            !house_block.brigadist.nil?
+          end
+
           attribute :brigadist do |house_block|
             "#{house_block.brigadist&.first_name}, #{house_block.brigadist&.last_name}"
           end

--- a/app/concepts/api/v1/houses/serializers/list_to_visit.rb
+++ b/app/concepts/api/v1/houses/serializers/list_to_visit.rb
@@ -68,7 +68,7 @@ module Api
             last_visit = Visit.where(house_id: house.id).last
             next unless last_visit
 
-            last_visit.created_at.strftime("%d/%m/%Y")
+            last_visit.created_at.to_time.to_i
           end
         end
       end

--- a/app/concepts/api/v1/users/accounts/contracts/change_team.rb
+++ b/app/concepts/api/v1/users/accounts/contracts/change_team.rb
@@ -1,0 +1,41 @@
+require 'dry/validation/contract'
+
+module Api
+  module V1
+    module Users
+      module Accounts
+        module Contracts
+          class ChangeTeam < Dry::Validation::Contract
+            def self.kall(...)
+              new.call(...)
+            end
+
+            params do
+              required(:team_id).filled(:integer)
+              required(:house_block_id).filled(:integer)
+            end
+
+            rule(:team_id) do
+              if values[:team_id] && !Team.kept.exists?(id: values[:team_id])
+                key(:team_id).failure(text: "The brigade with id #{values[:team_id]} not exists", predicate: :not_exists?)
+              end
+            end
+
+            rule(:house_block_id) do
+              if values[:house_block_id] && !HouseBlock.exists?(id: values[:house_block_id])
+                key(:team_id).failure(text: "The HouseBlock with id #{values[:house_block_id]} not exists",
+                                      predicate: :not_exists?)
+              end
+
+              if values[:team_id] && values[:house_block_id] && HouseBlock.find_by(id: values[:house_block_id])&.team_id != values[:team_id]
+                key(:house_team_id).failure(
+                  text: "The HouseBlock with id #{values[:house_block_id]} is not belongs to the new team", predicate: :is_new?)
+              end
+            end
+
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/users/accounts/operations/change_team.rb
+++ b/app/concepts/api/v1/users/accounts/operations/change_team.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Users
+      module Accounts
+        module Operations
+          class ChangeTeam < ApplicationOperation
+            include Dry::Transaction
+
+            tee :params
+            step :validate_schema
+            step :update_user
+            tee :add_includes
+
+            def params(input)
+              @ctx = {}
+              @params = to_snake_case(input[:params])
+              @input = input[:params]
+              @current_user = input[:current_user]
+            end
+            def validate_schema
+              @ctx['contract.default'] = Api::V1::Users::Accounts::Contracts::ChangeTeam.kall(@params)
+              is_valid = @ctx['contract.default'].success?
+              return Success({ ctx: @ctx, type: :success }) if is_valid
+
+              Failure({ ctx: @ctx, type: :invalid }) unless is_valid
+            end
+
+            def update_user
+              attrs = @ctx['contract.default'].values.data
+              attrs[:house_block_ids] = attrs.delete(:house_block_id)
+              user_profile = @current_user.user_profile
+              user_profile.update!(attrs)
+              @ctx[:model] = @current_user
+              Success({ ctx: @ctx, type: :success })
+            end
+
+            def add_includes
+              @ctx[:include] = 'user_profile'
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/users/accounts/serializers/show.rb
+++ b/app/concepts/api/v1/users/accounts/serializers/show.rb
@@ -56,6 +56,16 @@ module Api
               }
             end
 
+            attribute :house_block do |user_profile|
+              next if user_profile.house_blocks.blank?
+
+              {
+                id: user_profile.house_blocks.first.id,
+                name: user_profile.house_blocks.first.name,
+                house_ids: Api::V1::Houses::Queries::ListToVisit.call(user_profile.user_account, nil)&.pluck(:id)
+              }
+            end
+
             attribute :roles do |user_profile|
               user_profile.roles&.map do |role|
                 {

--- a/app/concepts/api/v1/users/accounts/serializers/user_profile.rb
+++ b/app/concepts/api/v1/users/accounts/serializers/user_profile.rb
@@ -35,6 +35,16 @@ module Api
               user_profile.team&.name
             end
 
+            attribute :house_block do |user_profile|
+              next if user_profile.house_blocks.blank?
+
+              {
+                id: user_profile.house_blocks.first.id,
+                name: user_profile.house_blocks.first.name,
+                house_ids: Api::V1::Houses::Queries::ListToVisit.call(user_profile.user_account, nil)&.pluck(:id)
+              }
+            end
+
           end
         end
       end

--- a/app/concepts/api/v1/visits/operations/create.rb
+++ b/app/concepts/api/v1/visits/operations/create.rb
@@ -11,6 +11,7 @@ module Api
           step :validate_schema
           tee :split_data
           step :create_house_if_necessary
+          step :add_team
           step :create_visit
           tee :set_extra_info_to_inspections
           step :create_inspections
@@ -43,6 +44,14 @@ module Api
             return existing_house_result if params_include_house?
 
             @params[:house_id] = find_similar_or_create_house_id
+            Success({ ctx: @ctx, type: :success })
+          end
+
+          def add_team
+            return  Success({ ctx: @ctx, type: :success }) if @params[:team_id]&.present?
+            return nil unless @current_user.teams.any?
+
+            @params[:team_id] = @current_user.teams.first.id
             Success({ ctx: @ctx, type: :success })
           end
 

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -34,6 +34,14 @@ module Api
                  options: { current_user: }
       end
 
+      def change_team
+        endpoint operation: Api::V1::Users::Accounts::Operations::ChangeTeam,
+                 renderer_options: {
+                   serializer: Api::V1::Users::Accounts::Serializers::ShowCurrentUser
+                 },
+                 options: { current_user: }
+      end
+
     end
   end
 end

--- a/app/models/house_block.rb
+++ b/app/models/house_block.rb
@@ -7,8 +7,8 @@
 #  name            :string
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
-#  team_id         :bigint           not null
-#  user_profile_id :bigint           not null
+#  team_id         :bigint
+#  user_profile_id :bigint
 #  wedge_id        :bigint
 #
 # Indexes
@@ -25,7 +25,7 @@
 #
 class HouseBlock < ApplicationRecord
   has_many :houses, dependent: :nullify
-  belongs_to :team
-  belongs_to :brigadist, class_name: 'UserProfile', foreign_key: 'user_profile_id'
+  belongs_to :team, optional: true
+  belongs_to :brigadist, class_name: 'UserProfile', foreign_key: 'user_profile_id', optional: true
   belongs_to :wedge, class_name: 'Wedge', foreign_key: 'wedge_id'
 end

--- a/config/initializers/constants/permission_codes.rb
+++ b/config/initializers/constants/permission_codes.rb
@@ -66,7 +66,8 @@ module Constants
       wedges_index: :wedges_index,
       get_last_params_index: :get_last_params,
       questionnaires_current: :questionnaires_current,
-      houses_list_to_visit: :houses_list_to_visit
+      houses_list_to_visit: :houses_list_to_visit,
+      users_show_current_user: :users_show_current_user
     }.freeze
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
       resources :users, only: %i[index update show] do
         get 'me', on: :collection, action: :show_current_user
         get 'get_by_id/:id', on: :collection, action: :show
+        put 'change_team/', on: :collection, action: :change_team
       end
       resources :roles, only: %i[index update create]
       resources :permissions, only: %i[index show]

--- a/db/migrate/20240830070903_change_user_profile_and_team_in_house_blocks.rb
+++ b/db/migrate/20240830070903_change_user_profile_and_team_in_house_blocks.rb
@@ -1,0 +1,6 @@
+class ChangeUserProfileAndTeamInHouseBlocks < ActiveRecord::Migration[7.1]
+  def change
+    change_column_null :house_blocks, :team_id, true
+    change_column_null :house_blocks, :user_profile_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_21_035743) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_30_070903) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -103,8 +103,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_21_035743) do
 
   create_table "house_blocks", force: :cascade do |t|
     t.datetime "discarded_at"
-    t.bigint "team_id", null: false
-    t.bigint "user_profile_id", null: false
+    t.bigint "team_id"
+    t.bigint "user_profile_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -406,3 +406,11 @@ unless SeedTask.find_by(task_name: 'create_visit_and_list_house_permissions')
   role.save
   SeedTask.create(task_name: 'create_visit_and_list_house_permissions')
 end
+
+
+unless SeedTask.find_by(task_name: 'permissions_for_change_brigade')
+  roles = Role.where(name: %w[admin brigadista])
+  permission = Permission.create(name: 'change_team', resource: 'users')
+  roles.each{|rol| rol.permissions << permission}
+  SeedTask.create(task_name: 'permissions_for_change_brigade')
+end


### PR DESCRIPTION
Implemented a new `change_team` operation, including validation contracts and necessary migrations. Updated serializers and seeds to account for team changes. Adjusted house block model and related schemas to support optional team and user profile relationships.