### PR TITLE
Add wedge filters to team queries

### DIFF
--- a/app/concepts/api/v1/teams/contracts/index.rb
+++ b/app/concepts/api/v1/teams/contracts/index.rb
@@ -13,6 +13,8 @@ module Api
               optional(:name).maybe(:string)
               optional(:sector_id).maybe(:integer)
               optional(:sector).maybe(:string)
+              optional(:wedge_id).maybe(:integer)
+              optional(:wedge).maybe(:string)
             end
 
             optional(:page).maybe(:hash) do

--- a/app/concepts/api/v1/teams/queries/index.rb
+++ b/app/concepts/api/v1/teams/queries/index.rb
@@ -22,6 +22,8 @@ module Api
                   .yield_self(&method(:name_clause))
                   .yield_self(&method(:sector_id_clause))
                   .yield_self(&method(:sector_name_clause))
+                  .yield_self(&method(:wedge_id_clause))
+                  .yield_self(&method(:wedge_name_clause))
                   .yield_self(&method(:sort_clause))
           end
 
@@ -45,6 +47,18 @@ module Api
             return relation if @filter.nil? || @filter[:sector].blank?
 
             relation.joins(:sector).where('neighborhoods.name ILIKE ?', "%#{@filter[:sector]}%")
+          end
+
+          def wedge_id_clause(relation)
+            return relation if @filter.nil? || @filter[:wedge_id].nil? || @filter[:wedge_id].blank?
+
+            relation.where(wedge_id: @filter[:wedge_id])
+          end
+
+          def wedge_name_clause(relation)
+            return relation if @filter.nil? || @filter[:wedge].blank?
+
+            relation.joins(:wedge).where('wedges.name ILIKE ?', "%#{@filter[:wedge]}%")
           end
 
           def sort_clause(relation)


### PR DESCRIPTION
Introduce 'wedge_id' and 'wedge' parameters to the team queries and contract filters. This allows filtering teams based on wedge data, enhancing query specificity and flexibility.