### PR TITLE
Add team visits and site statuses to team serializer

### DIFF
--- a/app/concepts/api/v1/teams/serializers/show.rb
+++ b/app/concepts/api/v1/teams/serializers/show.rb
@@ -49,6 +49,19 @@ module Api
             }
           end
 
+          attribute :visits do |brigade|
+            Visit.where(team_id: brigade.id).count
+          end
+
+          attribute :visits do |brigade|
+            Visit.where(team_id: brigade.id).count
+          end
+
+          attribute :sites_statuses do |brigade|
+            House.where(team_id: brigade.id)
+                 .group(:status)
+                 .count
+          end
         end
       end
     end


### PR DESCRIPTION
This commit introduces two new attributes to the team serializer: `visits`, which counts the number of visits associated with a team, and `sites_statuses`, which groups and counts houses by their status for a team. These additions enhance