### PR TITLE
Remove `in_use` column from inspections

### DIFF
--- a/app/concepts/api/v1/visits/contracts/inspection.rb
+++ b/app/concepts/api/v1/visits/contracts/inspection.rb
@@ -10,7 +10,6 @@ module Api
             optional(:container_test_result).filled(:string) #optional
             required(:has_lid).filled(:bool)
             required(:has_water).filled(:bool)
-            optional(:in_use).filled(:bool) #optional
             optional(:tracking_type_required).filled(:string) #optional
             required(:was_chemically_treated).filled(:bool)
             optional(:created_by_id).filled(:integer)

--- a/app/models/inspection.rb
+++ b/app/models/inspection.rb
@@ -7,7 +7,6 @@
 #  container_test_result      :string
 #  has_lid                    :boolean
 #  has_water                  :boolean
-#  in_use                     :boolean
 #  tracking_type_required     :string
 #  was_chemically_treated     :boolean
 #  created_at                 :datetime         not null

--- a/db/migrate/20240906151850_remove_in_use_to_inspections.rb
+++ b/db/migrate/20240906151850_remove_in_use_to_inspections.rb
@@ -1,0 +1,5 @@
+class RemoveInUseToInspections < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :inspections, :in_use, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_04_123451) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_06_151850) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -159,7 +159,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_04_123451) do
     t.bigint "created_by_id", null: false
     t.bigint "treated_by_id", null: false
     t.string "code_reference"
-    t.boolean "in_use"
     t.boolean "has_lid"
     t.boolean "has_water"
     t.boolean "was_chemically_treated"


### PR DESCRIPTION
This migration removes the `in_use` boolean column from the inspections table. The related validator and model annotations are also updated to reflect this change. This cleanup is part of ongoing database and model optimizations.