### PR TITLE
Add water_source_other to inspections

### DIFF
--- a/app/concepts/api/v1/visits/contracts/inspection.rb
+++ b/app/concepts/api/v1/visits/contracts/inspection.rb
@@ -17,6 +17,7 @@ module Api
             required(:breeding_site_type_id).filled(:integer)
             required(:elimination_method_type_id).filled(:integer)
             required(:water_source_type_id).filled(:integer)
+            other(:water_source_other).filled(:string)
           end
 
           rule(:breeding_site_type_id) do

--- a/app/models/inspection.rb
+++ b/app/models/inspection.rb
@@ -9,6 +9,7 @@
 #  has_water                  :boolean
 #  tracking_type_required     :string
 #  was_chemically_treated     :boolean
+#  water_source_other         :string
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null
 #  breeding_site_type_id      :bigint           not null

--- a/db/migrate/20240906152336_add_water_source_other_to_inspections.rb
+++ b/db/migrate/20240906152336_add_water_source_other_to_inspections.rb
@@ -1,0 +1,5 @@
+class AddWaterSourceOtherToInspections < ActiveRecord::Migration[7.1]
+  def change
+    add_column :inspections, :water_source_other, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_06_151850) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_06_152336) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -166,6 +166,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_06_151850) do
     t.string "tracking_type_required"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "water_source_other"
     t.index ["breeding_site_type_id"], name: "index_inspections_on_breeding_site_type_id"
     t.index ["created_by_id"], name: "index_inspections_on_created_by_id"
     t.index ["elimination_method_type_id"], name: "index_inspections_on_elimination_method_type_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -288,7 +288,13 @@ end
 
 #create water sources types
 unless SeedTask.find_by(task_name: 'create_water_sources_types')
-  WaterSourceType.create!([{ name: 'Naturaleza' }, { name: 'Residente' }])
+  WaterSourceType.create!(
+    [
+      { name: 'Agua de grifo' },
+      { name: 'Lluvia activamente recogida' },
+      { name: 'Lluvia pasivamente recogida' },
+      { name: 'Otro' }
+    ])
   SeedTask.create!(task_name: 'create_water_sources_types')
 end
 


### PR DESCRIPTION
This commit introduces a new column `water_source_other` to the inspections table to allow for additional water source types. It also updates the corresponding seed data and validations to accommodate the new field.