### PR TITLE
Remove has_lid column and add lid_type fields

### DIFF
--- a/app/concepts/api/v1/visits/contracts/inspection.rb
+++ b/app/concepts/api/v1/visits/contracts/inspection.rb
@@ -8,7 +8,6 @@ module Api
           params do
             optional(:code_reference).filled(:string)
             optional(:container_test_result).filled(:string) #optional
-            required(:has_lid).filled(:bool)
             required(:has_water).filled(:bool)
             optional(:tracking_type_required).filled(:string) #optional
             required(:was_chemically_treated).filled(:bool)
@@ -17,7 +16,9 @@ module Api
             required(:breeding_site_type_id).filled(:integer)
             required(:elimination_method_type_id).filled(:integer)
             required(:water_source_type_id).filled(:integer)
-            other(:water_source_other).filled(:string)
+            optional(:water_source_other).filled(:string)
+            required(:lid_type).filled(:string)
+            optional(:lid_type_other).filled(:string)
           end
 
           rule(:breeding_site_type_id) do

--- a/app/models/inspection.rb
+++ b/app/models/inspection.rb
@@ -5,8 +5,9 @@
 #  id                         :bigint           not null, primary key
 #  code_reference             :string
 #  container_test_result      :string
-#  has_lid                    :boolean
 #  has_water                  :boolean
+#  lid_type                   :string
+#  lid_type_other             :string
 #  tracking_type_required     :string
 #  was_chemically_treated     :boolean
 #  water_source_other         :string

--- a/db/migrate/20240906154413_remove_has_lid_to_inspections.rb
+++ b/db/migrate/20240906154413_remove_has_lid_to_inspections.rb
@@ -1,0 +1,5 @@
+class RemoveHasLidToInspections < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :inspections, :has_lid, if_exists: true
+  end
+end

--- a/db/migrate/20240906154539_add_new_fields_by_lid_to_inspects.rb
+++ b/db/migrate/20240906154539_add_new_fields_by_lid_to_inspects.rb
@@ -1,0 +1,6 @@
+class AddNewFieldsByLidToInspects < ActiveRecord::Migration[7.1]
+  def change
+    add_column :inspections, :lid_type, :string
+    add_column :inspections, :lid_type_other, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_06_152336) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_06_154539) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -159,7 +159,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_06_152336) do
     t.bigint "created_by_id", null: false
     t.bigint "treated_by_id", null: false
     t.string "code_reference"
-    t.boolean "has_lid"
     t.boolean "has_water"
     t.boolean "was_chemically_treated"
     t.string "container_test_result"
@@ -167,6 +166,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_06_152336) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "water_source_other"
+    t.string "lid_type"
+    t.string "lid_type_other"
     t.index ["breeding_site_type_id"], name: "index_inspections_on_breeding_site_type_id"
     t.index ["created_by_id"], name: "index_inspections_on_created_by_id"
     t.index ["elimination_method_type_id"], name: "index_inspections_on_elimination_method_type_id"


### PR DESCRIPTION
Removed the `has_lid` column from inspections table and replaced it with `lid_type` and `lid_type_other` fields. Updated schema and related files to reflect these changes.