### PR TITLE
Add models and migrations for container protections and type contents

### DIFF
--- a/app/models/container_protection.rb
+++ b/app/models/container_protection.rb
@@ -1,0 +1,19 @@
+# == Schema Information
+#
+# Table name: container_protections
+#
+#  id           :bigint           not null, primary key
+#  color        :string
+#  discarded_at :datetime
+#  name_en      :string
+#  name_es      :string
+#  name_pt      :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+class ContainerProtection < ApplicationRecord
+  include Discard::Model
+
+  has_many :inspections, dependent: :nullify
+
+end

--- a/app/models/inspection.rb
+++ b/app/models/inspection.rb
@@ -8,12 +8,14 @@
 #  has_water                  :boolean
 #  lid_type                   :string
 #  lid_type_other             :string
+#  other_protection           :string
 #  tracking_type_required     :string
 #  was_chemically_treated     :boolean
 #  water_source_other         :string
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null
 #  breeding_site_type_id      :bigint           not null
+#  container_protection_id    :bigint
 #  created_by_id              :bigint           not null
 #  elimination_method_type_id :bigint           not null
 #  treated_by_id              :bigint           not null
@@ -23,6 +25,7 @@
 # Indexes
 #
 #  index_inspections_on_breeding_site_type_id       (breeding_site_type_id)
+#  index_inspections_on_container_protection_id     (container_protection_id)
 #  index_inspections_on_created_by_id               (created_by_id)
 #  index_inspections_on_elimination_method_type_id  (elimination_method_type_id)
 #  index_inspections_on_treated_by_id               (treated_by_id)
@@ -32,6 +35,7 @@
 # Foreign Keys
 #
 #  fk_rails_...  (breeding_site_type_id => breeding_site_types.id)
+#  fk_rails_...  (container_protection_id => container_protections.id)
 #  fk_rails_...  (created_by_id => user_accounts.id)
 #  fk_rails_...  (elimination_method_type_id => elimination_method_types.id)
 #  fk_rails_...  (treated_by_id => user_accounts.id)
@@ -45,4 +49,7 @@ class Inspection < ApplicationRecord
   belongs_to :water_source_type
   belongs_to :created_by, class_name: 'UserAccount'
   belongs_to :treated_by, class_name: 'UserAccount'
+  belongs_to :container_protection, optional: true
+  has_many :inspection_type_contents, dependent: :nullify
+  has_many :type_contents, through: :inspection_type_contents
 end

--- a/app/models/inspection_type_content.rb
+++ b/app/models/inspection_type_content.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class InspectionTypeContent < ApplicationRecord
+  belongs_to :inspection
+  belongs_to :type_content
+end

--- a/app/models/type_content.rb
+++ b/app/models/type_content.rb
@@ -1,0 +1,16 @@
+# == Schema Information
+#
+# Table name: type_contents
+#
+#  id           :bigint           not null, primary key
+#  discarded_at :datetime
+#  name_en      :string
+#  name_es      :string
+#  name_pt      :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+class TypeContent < ApplicationRecord
+  has_many :inspection_type_contents, dependent: :destroy
+  has_many :inspections, through: :inspection_type_contents
+end

--- a/db/migrate/20240911130841_create_container_protections.rb
+++ b/db/migrate/20240911130841_create_container_protections.rb
@@ -1,0 +1,16 @@
+class CreateContainerProtections < ActiveRecord::Migration[7.1]
+  def change
+    create_table :container_protections do |t|
+      t.string :name_es
+      t.string :name_en
+      t.string :name_pt
+      t.string :color
+      t.datetime :discarded_at
+
+      t.timestamps
+    end
+
+    add_reference :inspections, :container_protection, foreign_key: true, null: true
+    add_column :inspections, :other_protection, :string
+  end
+end

--- a/db/migrate/20240911132601_create_type_content.rb
+++ b/db/migrate/20240911132601_create_type_content.rb
@@ -1,0 +1,17 @@
+class CreateTypeContent < ActiveRecord::Migration[7.1]
+  def change
+    create_table :type_contents do |t|
+      t.string :name_es
+      t.string :name_en
+      t.string :name_pt
+      t.datetime :discarded_at
+
+      t.timestamps
+    end
+
+    create_table :inspections_type_contents, id: false do |t|
+      t.belongs_to :inspection, foreign_key: true
+      t.belongs_to :type_content, foreign_key: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_06_154539) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_11_132601) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -81,6 +81,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_06_154539) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "container_protections", force: :cascade do |t|
+    t.string "name_es"
+    t.string "name_en"
+    t.string "name_pt"
+    t.string "color"
+    t.datetime "discarded_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "container_types", force: :cascade do |t|
     t.string "name"
     t.bigint "breeding_site_type_id", null: false
@@ -97,13 +107,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_06_154539) do
     t.datetime "updated_at", null: false
     t.index ["discarded_at"], name: "index_countries_on_discarded_at"
     t.index ["name"], name: "index_countries_on_name"
-  end
-
-  create_table "create_visit_param_versions", force: :cascade do |t|
-    t.string "name"
-    t.integer "version", default: 1
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
   end
 
   create_table "elimination_method_types", force: :cascade do |t|
@@ -175,12 +178,22 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_06_154539) do
     t.string "water_source_other"
     t.string "lid_type"
     t.string "lid_type_other"
+    t.bigint "container_protection_id"
+    t.string "other_protection"
     t.index ["breeding_site_type_id"], name: "index_inspections_on_breeding_site_type_id"
+    t.index ["container_protection_id"], name: "index_inspections_on_container_protection_id"
     t.index ["created_by_id"], name: "index_inspections_on_created_by_id"
     t.index ["elimination_method_type_id"], name: "index_inspections_on_elimination_method_type_id"
     t.index ["treated_by_id"], name: "index_inspections_on_treated_by_id"
     t.index ["visit_id"], name: "index_inspections_on_visit_id"
     t.index ["water_source_type_id"], name: "index_inspections_on_water_source_type_id"
+  end
+
+  create_table "inspections_type_contents", id: false, force: :cascade do |t|
+    t.bigint "inspection_id"
+    t.bigint "type_content_id"
+    t.index ["inspection_id"], name: "index_inspections_type_contents_on_inspection_id"
+    t.index ["type_content_id"], name: "index_inspections_type_contents_on_type_content_id"
   end
 
   create_table "likes", force: :cascade do |t|
@@ -353,6 +366,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_06_154539) do
     t.index ["wedge_id"], name: "index_teams_on_wedge_id"
   end
 
+  create_table "type_contents", force: :cascade do |t|
+    t.string "name_es"
+    t.string "name_en"
+    t.string "name_pt"
+    t.datetime "discarded_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "user_accounts", force: :cascade do |t|
     t.string "password_digest"
     t.datetime "discarded_at"
@@ -472,11 +494,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_06_154539) do
   add_foreign_key "houses", "user_profiles"
   add_foreign_key "houses", "wedges"
   add_foreign_key "inspections", "breeding_site_types"
+  add_foreign_key "inspections", "container_protections"
   add_foreign_key "inspections", "elimination_method_types"
   add_foreign_key "inspections", "user_accounts", column: "created_by_id"
   add_foreign_key "inspections", "user_accounts", column: "treated_by_id"
   add_foreign_key "inspections", "visits"
   add_foreign_key "inspections", "water_source_types"
+  add_foreign_key "inspections_type_contents", "inspections"
+  add_foreign_key "inspections_type_contents", "type_contents"
   add_foreign_key "likes", "user_accounts"
   add_foreign_key "neighborhoods", "cities"
   add_foreign_key "neighborhoods", "countries"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -372,3 +372,22 @@ unless SeedTask.find_by(task_name: 'permissions_for_posts_likes_and_comments')
   roles.each {|rol| rol.permissions << permissions }
   SeedTask.create(task_name: 'permissions_for_posts_likes_and_comments')
 end
+
+
+
+unless SeedTask.find_by(task_name: 'add_container_protections')
+  ContainerProtection.create!(name_es: 'Tapa hermética', name_en: 'Hermetic lid', name_pt: 'Tampa hermética', color: 'green')
+  ContainerProtection.create!(name_es: 'Tapa no hermética', name_en: 'Non-hermetic lid', name_pt: 'Tampa não hermética', color: 'yellow')
+  ContainerProtection.create!(name_es: 'Techo', name_en: 'Roof', name_pt: 'Telhado', color: 'yellow')
+  ContainerProtection.create!(name_es: 'No tiene', name_en: 'None', name_pt: 'Sem proteção', color: 'red')
+  ContainerProtection.create!(name_es: 'Otro', name_en: 'Other', name_pt: 'Outro', color: 'yellow')
+  SeedTask.create!(task_name: 'add_container_protections')
+end
+
+unless SeedTask.find_by(task_name: 'add_type_contents')
+  TypeContent.create!(name_es: 'Larvas', name_en: 'Larvae', name_pt: 'Larvas')
+  TypeContent.create!(name_es: 'Pupas', name_en: 'Pupae', name_pt: 'Pupas')
+  TypeContent.create!(name_es: 'Huevos', name_en: 'Eggs', name_pt: 'Ovos')
+  TypeContent.create!(name_es: 'Nada', name_en: 'None', name_pt: 'Nada')
+  SeedTask.create!(task_name: 'add_type_contents')
+end


### PR DESCRIPTION
This commit introduces two new models: ContainerProtection and TypeContent along with their respective migrations. Enhancements include associations between Inspections and these new models, and relevant seed data is also added to the seeds.rb file for initial setup.