### PR TITLE
Add container_type to ContainerType model and seed data

### DIFF
--- a/app/models/container_type.rb
+++ b/app/models/container_type.rb
@@ -3,6 +3,7 @@
 # Table name: container_types
 #
 #  id                    :bigint           not null, primary key
+#  container_type        :string
 #  discarded_at          :datetime
 #  name                  :string
 #  created_at            :datetime         not null

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_11_132601) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_11_153521) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -97,6 +97,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_11_132601) do
     t.datetime "discarded_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "container_type"
     t.index ["breeding_site_type_id"], name: "index_container_types_on_breeding_site_type_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -244,31 +244,32 @@ unless SeedTask.find_by(task_name: 'create_breeding_site_types')
 end
 
 #create container types
-unless SeedTask.find_by(task_name: 'create_container_types')
+unless SeedTask.find_by(task_name: 'create_container_types_v2')
   breeding_site_first, breeding_site_second = BreedingSiteType.first, BreedingSiteType.second
+  ContainerType.delete_all
 
   ContainerType.create!(name: 'Tanques (cemento, polietileno, metal, otra) ',
-                       breeding_site_type: breeding_site_first)
+                       breeding_site_type: breeding_site_first, container_type: 'permanent')
 
   ContainerType.create!(name: 'Bidones/Cilindros (metal, plástico)',
-                       breeding_site_type: breeding_site_first)
+                       breeding_site_type: breeding_site_first, container_type: 'permanent')
 
   ContainerType.create!(name: 'Pozos',
-                       breeding_site_type: breeding_site_first)
+                       breeding_site_type: breeding_site_first, container_type: 'permanent')
 
   ContainerType.create!(name: 'Estructura o Partes de la Casa',
-                       breeding_site_type: breeding_site_first)
+                       breeding_site_type: breeding_site_first, container_type: 'permanent')
 
   ContainerType.create!(name: 'Llanta',
-                       breeding_site_type: breeding_site_second)
+                       breeding_site_type: breeding_site_second, container_type: 'non-permanent')
 
   ContainerType.create!(name: 'Otros',
-                       breeding_site_type: breeding_site_second)
+                       breeding_site_type: breeding_site_second, container_type: 'non-permanent')
 
   ContainerType.create!(name: 'Elementos naturales',
-                       breeding_site_type: breeding_site_second)
+                       breeding_site_type: breeding_site_second, container_type: 'non-permanent')
 
-  SeedTask.create!(task_name: 'create_container_types')
+  SeedTask.create!(task_name: 'create_container_types_v2')
 end
 
 # assign images to container types


### PR DESCRIPTION
Introduced a new 'container_type' field in the ContainerType model to differentiate between 'permanent' and 'non-permanent' types. Updated seed data script to populate this new field and adjusted the task name to avoid conflicts.