### PR TITLE
Add full name filter to user accounts query

### DIFF
--- a/app/concepts/api/v1/users/accounts/contracts/index.rb
+++ b/app/concepts/api/v1/users/accounts/contracts/index.rb
@@ -13,6 +13,7 @@ module Api
               optional(:filter).maybe(:hash) do
                 optional(:first_name).maybe(:string)
                 optional(:last_name).maybe(:string)
+                optional(:full_name).maybe(:string)
                 optional(:phone).maybe(:string)
                 optional(:email).maybe(:string)
                 optional(:username).maybe(:string)

--- a/app/concepts/api/v1/users/accounts/queries/index.rb
+++ b/app/concepts/api/v1/users/accounts/queries/index.rb
@@ -21,6 +21,7 @@ module Api
 
             def call
               @model.yield_self(&method(:active_records))
+                    .yield_self(&method(:full_name_clause))
                     .yield_self(&method(:first_name_clause))
                     .yield_self(&method(:last_name_clause))
                     .yield_self(&method(:phone_clause))
@@ -38,6 +39,12 @@ module Api
 
             def active_records(relation)
               relation.where(user_account: {discarded_at: nil})
+            end
+
+            def full_name_clause(relation)
+              return relation if @filter.nil? || @filter[:full_name].blank?
+
+              relation.where('user_profiles.first_name ilike :query OR user_profiles.last_name ilike :query', query: "%#{@filter[:full_name]}%")
             end
 
             def first_name_clause(relation)


### PR DESCRIPTION
This commit enhances the user accounts query by introducing a new filter parameter `full_name`. The associated contract has been updated to include an optional `full_name` string which allows searching by either first or last name using a case-insensitive match.