### PR TITLE
Add geocoder gem to Gemfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,6 +231,9 @@ GEM
     fuubar (2.5.1)
       rspec-core (~> 3.0)
       ruby-progressbar (~> 1.4)
+    geocoder (1.8.3)
+      base64 (>= 0.1.0)
+      csv (>= 3.0.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashdiff (1.1.0)
@@ -546,6 +549,7 @@ DEPENDENCIES
   fasterer (~> 0.10)
   ffaker
   fuubar (~> 2.5)
+  geocoder
   httparty
   image_processing (~> 1.2)
   json_matchers (~> 0.11)


### PR DESCRIPTION
Included the geocoder gem to facilitate address lookup and geocoding functionality within the application. This addition may improve location-based features and enhance user experience through precise geographic data parsing.