### PR TITLE
Add internationalization to SpecialPlace model

### DIFF
--- a/app/models/special_place.rb
+++ b/app/models/special_place.rb
@@ -4,7 +4,9 @@
 #
 #  id           :bigint           not null, primary key
 #  discarded_at :datetime
-#  name         :string
+#  name_en      :string
+#  name_es      :string
+#  name_pt      :string
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #

--- a/config/initializers/constants/visit_params.rb
+++ b/config/initializers/constants/visit_params.rb
@@ -2,6 +2,6 @@
 
 module Constants
   module VisitParams
-    RESOURCES = %w[breeding_site_types container_types elimination_method_types water_source_types places].freeze
+    RESOURCES = %w[breeding_site_types container_types elimination_method_types water_source_types special_places].freeze
   end
 end

--- a/db/migrate/20240919130245_add_internationalization_to_special_places.rb
+++ b/db/migrate/20240919130245_add_internationalization_to_special_places.rb
@@ -1,0 +1,8 @@
+class AddInternationalizationToSpecialPlaces < ActiveRecord::Migration[7.1]
+  def change
+    add_column :special_places, :name_es, :string
+    add_column :special_places, :name_en, :string
+    add_column :special_places, :name_pt, :string
+    remove_column :special_places, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_18_204605) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_19_130245) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "unaccent"
@@ -340,10 +340,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_18_204605) do
   end
 
   create_table "special_places", force: :cascade do |t|
-    t.string "name"
     t.datetime "discarded_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "name_es"
+    t.string "name_en"
+    t.string "name_pt"
   end
 
   create_table "states", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -86,7 +86,7 @@ unless SeedTask.find_by(task_name: 'clean_db_v4')
   Neighborhood.destroy_all
   State.destroy_all
   SeedTask.where(task_name: task_to_re_run).destroy_all
-  SeedTask.create!(task_name: 'clean_db_v4') if State.count > 0 && City.count > 0
+  SeedTask.create!(task_name: 'clean_db_v4') if State.count.zero? && City.count.zero?
 
 end
 
@@ -115,7 +115,7 @@ unless SeedTask.find_by(task_name: 'states_and_cities_v2')
     end
   end
 
-  SeedTask.create!(task_name: 'states_and_cities_v2') if State.count > 0 && City.count > 0
+  SeedTask.create!(task_name: 'states_and_cities_v2') if State.count.positive? && City.count.positive?
 end
 
 #create default wedges
@@ -128,10 +128,14 @@ unless SeedTask.find_by(task_name: 'create_wedges')
 end
 
 #create default special_places
-unless SeedTask.find_by(task_name: 'create_special_places')
-  SpecialPlace.create!(name: 'Cementerio')
-  SpecialPlace.create!(name: 'Colegio')
-  SeedTask.create!(task_name: 'create_special_places')
+unless SeedTask.find_by(task_name: 'create_special_places_v1')
+  SpecialPlace.destroy_all
+  SpecialPlace.create!(name_es: 'Organizaciones', name_en: 'Organizations', name_pt: 'Organizações')
+  SpecialPlace.create!(name_es: 'Huerta', name_en: 'Garden', name_pt: 'Horta')
+  SpecialPlace.create!(name_es: 'Educación', name_en: 'Education', name_pt: 'Educação')
+  SpecialPlace.create!(name_es: 'Casa', name_en: 'House', name_pt: 'Casa')
+  SpecialPlace.create!(name_es: 'Negocio', name_en: 'Business', name_pt: 'Negócio')
+  SeedTask.create!(task_name: 'create_special_places_v1')
 end
 
 # default organization
@@ -250,11 +254,7 @@ end
 
 
 
-#create house-places
-unless SeedTask.find_by(task_name: 'create_places')
-  Place.create!([{ name: 'Cementerio' }, { name: 'Plaza' }])
-  SeedTask.create!(task_name: 'create_places')
-end
+
 
 #create default versions params
 unless SeedTask.find_by(task_name: 'create_visit_params')
@@ -332,6 +332,9 @@ unless SeedTask.find_by(task_name: 'permission_for_find_address')
   SeedTask.create(task_name: 'permission_for_find_address')
 end
 
-
+unless SeedTask.find_by(task_name: 'special_place_to_last_params')
+  VisitParamVersion.find_or_create_by(name: 'special_places')
+  SeedTask.create(task_name: 'special_place_to_last_params')
+end
 
 


### PR DESCRIPTION
Added 'name_es', 'name_en', and 'name_pt' columns to support internationalization while removing the old 'name' column. Updated seed data to reflect new structure and ensured seed tasks check for new conditions. Modified constant 'RESOURCES' to include 'special_places' for visit parameters.