### PR TITLE
Fix update_user method to handle missing user_profile_attributes

### DIFF
--- a/app/concepts/api/v1/users/accounts/operations/update.rb
+++ b/app/concepts/api/v1/users/accounts/operations/update.rb
@@ -38,7 +38,10 @@ module Api
 
             def update_user
               attrs = @ctx['contract.default'].values.data
-              attrs[:user_profile_attributes][:house_block_ids] = attrs[:user_profile_attributes].delete(:house_block_id)
+              if attrs[:user_profile_attributes]
+                attrs[:user_profile_attributes][:house_block_ids] =
+                  attrs[:user_profile_attributes].delete(:house_block_id)
+              end
               attrs.delete(:id)
               if @input['password']
                 attrs['password'] = @input[:password]


### PR DESCRIPTION
The update_user method now checks if user_profile_attributes exist before trying to access it. This prevents potential errors when user_profile_attributes is nil, ensuring the code runs smoothly even in edge cases.