### PR TITLE
Add multilingual support for SpecialPlaces and enhance sort

### DIFF
--- a/app/concepts/api/v1/cities/operations/index.rb
+++ b/app/concepts/api/v1/cities/operations/index.rb
@@ -30,7 +30,9 @@ module Api
           end
 
           def cursor_and_paginate
-            @ctx[:sort] = { field: 'Cities.name', direction: 'asc' }
+            sort = @params['sort'] || 'cities.name'
+            order = @params['order'] || 'desc'
+            @ctx[:sort] = { field: sort, direction: order }
           end
 
           def list

--- a/app/concepts/api/v1/cities/queries/index.rb
+++ b/app/concepts/api/v1/cities/queries/index.rb
@@ -52,11 +52,7 @@ module Api
           def sort_clause(relation)
             return relation if @sort.nil? || @sort.blank?
 
-            case @sort[:field]
-            when 'name', 'status' then sort_by_status_and_name(relation, :cities)
-            when 'Cities.name' then sort_by_table_columns(relation)
-            else relation
-            end
+            sort_by_table_columns(relation)
           end
         end
       end

--- a/app/concepts/api/v1/houses/serializers/index.rb
+++ b/app/concepts/api/v1/houses/serializers/index.rb
@@ -68,7 +68,9 @@ module Api
 
             {
               id: house.special_place.id,
-              name: house.special_place.name
+              name: house.special_place.name_es,
+              name_en: house.special_place.name_en,
+              name_pt: house.special_place.name_pt
             }
           end
 

--- a/app/concepts/api/v1/houses/serializers/list_to_visit.rb
+++ b/app/concepts/api/v1/houses/serializers/list_to_visit.rb
@@ -60,7 +60,9 @@ module Api
 
             {
               id: house.special_place.id,
-              name: house.special_place.name
+              name: house.special_place.name_es,
+              name_en: house.special_place.name_en,
+              name_pt: house.special_place.name_pt
             }
           end
 

--- a/app/concepts/api/v1/special_places/contracts/create.rb
+++ b/app/concepts/api/v1/special_places/contracts/create.rb
@@ -11,7 +11,10 @@ module Api
           end
 
           params do
-            required(:name).filled(:string)
+            optional(:name).filled(:string)
+            optional(:name_es).filled(:string)
+            optional(:name_en).filled(:string)
+            optional(:name_pt).filled(:string)
           end
 
           rule(:name) do

--- a/app/concepts/api/v1/special_places/contracts/index.rb
+++ b/app/concepts/api/v1/special_places/contracts/index.rb
@@ -11,6 +11,9 @@ module Api
           params do
             optional(:filter).maybe(:hash) do
               optional(:name).maybe(:string)
+              optional(:name_es).maybe(:string)
+              optional(:name_en).maybe(:string)
+              optional(:name_pt).maybe(:string)
               optional(:status).maybe(:string, included_in?: %w[active inactive all])
             end
 

--- a/app/concepts/api/v1/special_places/contracts/update.rb
+++ b/app/concepts/api/v1/special_places/contracts/update.rb
@@ -11,7 +11,10 @@ module Api
 
           params do
             required(:id).filled(:integer)
-            required(:name).filled(:string)
+            optional(:name).filled(:string)
+            optional(:name_es).filled(:string)
+            optional(:name_pt).filled(:string)
+            optional(:name_en).filled(:string)
           end
         end
       end

--- a/app/concepts/api/v1/special_places/operations/index.rb
+++ b/app/concepts/api/v1/special_places/operations/index.rb
@@ -29,7 +29,7 @@ module Api
           end
 
           def cursor_and_paginate
-            @ctx[:sort] = { field: 'special_places.name', direction: 'asc' } if @params['sort'].nil?
+            @ctx[:sort] = { field: 'special_places.id', direction: 'asc' } if @params['sort'].nil?
             direction = @params['order'].nil? ? 'asc' : @params['order']
             @ctx[:sort] = { field: @params['sort'], direction: } if @params['sort']
           end

--- a/app/concepts/api/v1/special_places/queries/index.rb
+++ b/app/concepts/api/v1/special_places/queries/index.rb
@@ -57,11 +57,13 @@ module Api
           def name_clause(relation)
             return relation if @filter.nil? || @filter[:name].blank?
 
-            relation.where('special_places.name ilike :query', query: "%#{@filter[:name]}%")
+            relation.where(
+              'special_places.name_es ilike :query OR special_places.name_en ilike :query OR special_places.name_pt like :query', query: "%#{@filter[:name]}%")
           end
 
           def sort_clause(relation)
             return relation if @sort.nil? || @sort.blank?
+            @sort[:field] = 'name_es' if @sort[:field] == 'name'
 
             sort_by_table_columns(relation) if @sort[:field]
           end

--- a/app/concepts/api/v1/special_places/serializers/index.rb
+++ b/app/concepts/api/v1/special_places/serializers/index.rb
@@ -7,11 +7,12 @@ module Api
         class Index < ApplicationSerializer
           set_type :special_place
 
-          attributes :name, :created_at
+          attributes :name, :name_en, :name_pt, :created_at
 
           attribute :status do |special_place|
             special_place.discarded_at.nil?
           end
+
         end
       end
     end

--- a/app/concepts/api/v1/special_places/serializers/show.rb
+++ b/app/concepts/api/v1/special_places/serializers/show.rb
@@ -7,7 +7,7 @@ module Api
         class Show < ApplicationSerializer
           set_type :special_place
 
-          attributes :name, :created_at
+          attributes :name, :name_en, :name_pt, :created_at
 
           attribute :status do |special_place|
             special_place.discarded_at.nil?

--- a/app/concepts/api/v1/teams/queries/index.rb
+++ b/app/concepts/api/v1/teams/queries/index.rb
@@ -64,6 +64,7 @@ module Api
           def sort_clause(relation)
             return relation if @sort.nil? || @sort.blank?
 
+            @sort[:field] = 'neighborhood_id' if @sort[:field] == 'sector'
             sort_by_table_columns(relation) if @sort[:field]
           end
         end

--- a/app/models/special_place.rb
+++ b/app/models/special_place.rb
@@ -12,5 +12,7 @@
 #
 class SpecialPlace < ApplicationRecord
   include Discard::Model
+  alias_attribute :name, :name_es
+
 
 end

--- a/config/initializers/constants/permission_codes.rb
+++ b/config/initializers/constants/permission_codes.rb
@@ -58,6 +58,7 @@ module Constants
       visits_edit: :visits_edit,
       visits_update: :visits_update,
       cities_create: :cities_create,
+      cities_update: :cities_update,
       cities_index: :cities_index,
       cities_show: :cities_show,
       cities_destroy: :cities_destroy,
@@ -72,7 +73,22 @@ module Constants
       list_by_iquitos_location: :list_by_iquitos_location,
       users_show_current_user: :users_show_current_user,
       comments_like: :comments_like,
-      get_address_find_address: :get_address_find_address
+      get_address_find_address: :get_address_find_address,
+      special_places_update: :special_places_update,
+      countries_show: :countries_show,
+      countries_create: :countries_create,
+      countries_destroy: :countries_destroy,
+      countries_index: :countries_index,
+      countries_update: :countries_update,
+      states_index: :states_index,
+      states_show: :states_show,
+      states_create: :states_create,
+      states_update: :states_update,
+      states_destroy: :states_destroy,
+      neighborhoods_show: :neighborhoods_show,
+      neighborhoods_create: :neighborhoods_create,
+      neighborhoods_update: :neighborhoods_update,
+      neighborhoods_destroy: :neighborhoods_destroy
     }.freeze
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,11 @@ Rails.application.routes.draw do
         end
       end
       resources :locations, only: %i[index]
-      resources :special_places
+      resources :special_places do
+        collection do
+          delete :destroy
+        end
+      end
       resources :houses, only: %i[index] do
         collection do
           get :list_to_visit
@@ -106,7 +110,7 @@ Rails.application.routes.draw do
             end
           end
         end
-        resources :organizations, only: %i[index], controller: '/api/v1/organizations'
+        resources :organizations, only: %i[index show], controller: '/api/v1/organizations'
         resources :cities, only: %i[show index] do
           get '/', to: '/api/v1/cities#list_by_country_and_state_assumption', on: :collection
           get '/', to: '/api/v1/cities#show_by_country_and_state_assumption', on: :member


### PR DESCRIPTION
Updated multiple serializers and queries to support multilingual names (English, Spanish, Portuguese) for SpecialPlaces. Adjusted sorting logic to prioritize more relevant fields and enhanced routing and permission codes to better handle special places and other entities.