### PR TITLE
Add statusColor to questionnaire serializer

### DIFF
--- a/app/concepts/api/v1/questionnaires/serializers/show.rb
+++ b/app/concepts/api/v1/questionnaires/serializers/show.rb
@@ -40,6 +40,7 @@ module Api
                     resourceId: option.resource_id,
                     required: option.required,
                     optionType: option.type_option,
+                    statusColor: option.status_color,
                     image: get_image_obj.call(option),
                     next: option.next
                   }


### PR DESCRIPTION
This change updates the serializer to include the statusColor attribute for options in the questionnaire. This allows the front-end to properly display the color status of each option as intended.