### PR TITLE
Add soft delete for comments and implement comment deletion

### DIFF
--- a/app/concepts/api/v1/comments/contracts/destroy.rb
+++ b/app/concepts/api/v1/comments/contracts/destroy.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require 'ostruct'
+
+module Api
+  module V1
+    module Comments
+      module Contracts
+        class Destroy < Dry::Validation::Contract
+
+          def self.kall(...)
+            new.call(...)
+          end
+
+          params do
+            required(:id).filled(:integer)
+          end
+
+          rule(:id) do
+            unless Comment.find_by(id: values[:id])
+              key(:id).failure(text: 'Comment not found', predicate: :not_found?)
+            end
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/comments/operations/destroy.rb
+++ b/app/concepts/api/v1/comments/operations/destroy.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Comments
+      module Operations
+        class Destroy < ApplicationOperation
+          include Dry::Transaction
+
+          tee :params
+          step :validate_schema
+          tee :retrieve_comment
+          step :authorized_user?
+          step :delete_comment
+
+          def params(input)
+            @ctx = {}
+            @params = to_snake_case(input[:params])
+            @current_user = input[:current_user]
+            @params[:user_account_id] = @current_user.id
+          end
+
+          def validate_schema
+            @ctx['contract.default'] = Api::V1::Comments::Contracts::Destroy.kall(@params)
+            is_valid = @ctx['contract.default'].success?
+            return Success({ ctx: @ctx, type: :success }) if is_valid
+
+            return Failure({ ctx: @ctx, type: :invalid }) unless is_valid
+          end
+
+          def retrieve_comment
+            @ctx[:model] = Comment.find_by(id: @params[:id])
+          end
+
+          def authorized_user?
+            author = @ctx[:model].user_account
+            is_valid = author == @current_user || @current_user.has_role?(:admin)
+            return Success({ ctx: @ctx, type: :success }) if is_valid
+
+            Failure({ ctx: @ctx, type: :invalid, errors: ErrorFormater.new_error(field: :base, msg: 'Only an admin or the owner can delete this comment', custom_predicate: :without_permissions )})
+
+          end
+
+          def delete_comment
+            begin
+              @ctx[:model].discard!
+              Success({ ctx: @ctx, type: :success })
+            rescue => error
+              Failure({ ctx: @ctx, type: :invalid })
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/posts/serializers/index.rb
+++ b/app/concepts/api/v1/posts/serializers/index.rb
@@ -57,6 +57,7 @@ module Api
 
             post.comments.map do |comment|
               {
+                id: comment.id,
                 likesCount: comment.likes_count,
                 userAccountId: comment.user_account_id,
                 createdBy: "#{comment.user_account.first_name} #{comment.user_account.last_name}",

--- a/app/controllers/api/v1/comments_controller.rb
+++ b/app/controllers/api/v1/comments_controller.rb
@@ -24,6 +24,11 @@ module Api
                  renderer_options: { serializer: Api::V1::Comments::Serializers::Show },
                  options: { current_user: }
       end
+
+      def destroy
+        endpoint operation: Api::V1::Comments::Operations::Destroy,
+                 options: { current_user: }
+      end
     end
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -6,7 +6,7 @@
 #
 #  id              :bigint           not null, primary key
 #  content         :text
-#  deleted_at      :datetime
+#  discarded_at    :datetime
 #  likes_count     :integer
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
@@ -15,6 +15,7 @@
 #
 # Indexes
 #
+#  index_comments_on_discarded_at     (discarded_at)
 #  index_comments_on_post_id          (post_id)
 #  index_comments_on_user_account_id  (user_account_id)
 #
@@ -24,10 +25,18 @@
 #  fk_rails_...  (user_account_id => user_accounts.id)
 #
 class Comment < ApplicationRecord
+  include Discard::Model
+  default_scope -> { kept }
+
   belongs_to :post
   has_one_attached :photo
   has_many :likes, as: :likeable, dependent: :destroy
   belongs_to :user_account
 
-  validates :content, presence: true
+  scope :kept, -> { undiscarded.joins(:post).merge(Post.kept) }
+
+  def kept?
+    undiscarded? && post.kept?
+  end
+
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -6,7 +6,7 @@
 #
 #  id              :bigint           not null, primary key
 #  content         :text
-#  deleted_at      :datetime
+#  discarded_at    :datetime
 #  likes_count     :integer
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
@@ -20,6 +20,7 @@
 #
 #  index_posts_on_city_id          (city_id)
 #  index_posts_on_country_id       (country_id)
+#  index_posts_on_discarded_at     (discarded_at)
 #  index_posts_on_neighborhood_id  (neighborhood_id)
 #  index_posts_on_team_id          (team_id)
 #  index_posts_on_user_account_id  (user_account_id)
@@ -33,6 +34,9 @@
 #  fk_rails_...  (user_account_id => user_accounts.id)
 #
 class Post < ApplicationRecord
+  include Discard::Model
+  default_scope -> { kept }
+
   has_many_attached :photos
   has_many :likes, as: :likeable, dependent: :destroy
   has_many :comments, dependent: :destroy

--- a/config/initializers/constants/error_codes.rb
+++ b/config/initializers/constants/error_codes.rb
@@ -58,7 +58,8 @@ module Constants
       not_exists?: 53,
       not_found?: 54,
       user_account_locked?: 55,
-      unexpected_key: 56
+      unexpected_key: 56,
+      without_permissions: 57
     }.freeze
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,7 +56,7 @@ Rails.application.routes.draw do
         member do
           post 'like'
         end
-        resources :comments, only: %i[index create show] do
+        resources :comments, only: %i[index create show destroy] do
           member do
             post 'like'
           end

--- a/db/migrate/20240920183327_change_deleted_at_to_discarded_at_to_comment.rb
+++ b/db/migrate/20240920183327_change_deleted_at_to_discarded_at_to_comment.rb
@@ -1,0 +1,11 @@
+class ChangeDeletedAtToDiscardedAtToComment < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :comments, :deleted_at, :datetime
+    remove_column :posts, :deleted_at, :datetime
+    add_column :comments, :discarded_at, :datetime
+    add_column :posts, :discarded_at, :datetime
+
+    add_index :posts, :discarded_at
+    add_index :comments, :discarded_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_19_183623) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_20_183327) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "unaccent"
@@ -69,9 +69,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_19_183623) do
     t.integer "likes_count"
     t.bigint "post_id", null: false
     t.bigint "user_account_id", null: false
-    t.datetime "deleted_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "discarded_at"
+    t.index ["discarded_at"], name: "index_comments_on_discarded_at"
     t.index ["post_id"], name: "index_comments_on_post_id"
     t.index ["user_account_id"], name: "index_comments_on_user_account_id"
   end
@@ -263,7 +264,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_19_183623) do
   create_table "posts", force: :cascade do |t|
     t.text "content"
     t.integer "likes_count"
-    t.datetime "deleted_at"
     t.bigint "user_account_id", null: false
     t.bigint "team_id", null: false
     t.bigint "neighborhood_id", null: false
@@ -271,8 +271,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_19_183623) do
     t.bigint "country_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "discarded_at"
     t.index ["city_id"], name: "index_posts_on_city_id"
     t.index ["country_id"], name: "index_posts_on_country_id"
+    t.index ["discarded_at"], name: "index_posts_on_discarded_at"
     t.index ["neighborhood_id"], name: "index_posts_on_neighborhood_id"
     t.index ["team_id"], name: "index_posts_on_team_id"
     t.index ["user_account_id"], name: "index_posts_on_user_account_id"


### PR DESCRIPTION
Introduced soft delete functionality by replacing `deleted_at` with `discarded_at` for comments and posts. Added destroy operation and validation for comments, allowing only the comment owner or an admin to perform deletion. Also updated routes, controllers, and serializers accordingly.