### PR TITLE
Add post deletion functionality

### DIFF
--- a/app/concepts/api/v1/posts/contracts/destroy.rb
+++ b/app/concepts/api/v1/posts/contracts/destroy.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require 'ostruct'
+
+module Api
+  module V1
+    module Posts
+      module Contracts
+        class Destroy < Dry::Validation::Contract
+
+          def self.kall(...)
+            new.call(...)
+          end
+
+          params do
+            required(:id).filled(:integer)
+          end
+
+          rule(:id) do
+            unless Post.find_by(id: values[:id])
+              key(:id).failure(text: 'Post not found', predicate: :not_found?)
+            end
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/posts/operations/destroy.rb
+++ b/app/concepts/api/v1/posts/operations/destroy.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Posts
+      module Operations
+        class Destroy < ApplicationOperation
+          include Dry::Transaction
+
+          tee :params
+          step :validate_schema
+          tee :retrieve_post
+          step :authorized_user?
+          step :delete_post
+
+          def params(input)
+            @ctx = {}
+            @params = to_snake_case(input[:params])
+            @current_user = input[:current_user]
+            @params[:user_account_id] = @current_user.id
+          end
+
+          def validate_schema
+            @ctx['contract.default'] = Api::V1::Posts::Contracts::Destroy.kall(@params)
+            is_valid = @ctx['contract.default'].success?
+            return Success({ ctx: @ctx, type: :success }) if is_valid
+
+            return Failure({ ctx: @ctx, type: :invalid }) unless is_valid
+          end
+
+          def retrieve_post
+            @ctx[:model] = Post.find_by(id: @params[:id])
+          end
+
+          def authorized_user?
+            author = @ctx[:model].user_account
+            is_valid = author == @current_user || @current_user.has_role?(:admin)
+            return Success({ ctx: @ctx, type: :success }) if is_valid
+
+            Failure({ ctx: @ctx, type: :invalid, errors: ErrorFormater.new_error(field: :base, msg: 'Only an admin or the owner can delete this post', custom_predicate: :without_permissions )})
+
+          end
+
+          def delete_post
+            begin
+              @ctx[:model].discard!
+              Success({ ctx: @ctx, type: :success })
+            rescue => error
+              Failure({ ctx: @ctx, type: :invalid })
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -9,6 +9,7 @@ module Api
                  renderer_options: { serializer: Api::V1::Posts::Serializers::Index },
                  options: { current_user: }
       end
+
       def show
         endpoint operation: Api::V1::Posts::Operations::Show,
                  renderer_options: { serializer: Api::V1::Posts::Serializers::Show },
@@ -24,6 +25,11 @@ module Api
       def like
         endpoint operation: Api::V1::Posts::Operations::Like,
                  renderer_options: { serializer: Api::V1::Posts::Serializers::Show },
+                 options: { current_user: }
+      end
+
+      def destroy
+        endpoint operation: Api::V1::Posts::Operations::Destroy,
                  options: { current_user: }
       end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,7 +52,7 @@ Rails.application.routes.draw do
           get :current
         end
       end
-      resources :posts, only: %i[create show index] do
+      resources :posts, only: %i[create show index destroy] do
         member do
           post 'like'
         end


### PR DESCRIPTION
This commit introduces the ability to delete posts via the API. It includes a destroy contract for validation, an operation to handle the deletion logic, and updates to the routes and controller to support this new feature.