### PR TITLE
Add `value` and `disable_other_options` to `Option` model

### DIFF
--- a/app/concepts/api/v1/questionnaires/serializers/show.rb
+++ b/app/concepts/api/v1/questionnaires/serializers/show.rb
@@ -43,7 +43,8 @@ module Api
                     statusColor: option.status_color,
                     image: get_image_obj.call(option),
                     next: option.next
-                  }
+                  }.merge(option.type_option == 'boolean' ? {value: option.value} : {})
+                   .merge(question.type_field == 'multiple' ? {disableOtherOptions: option.disable_other_options} : {})
                 end
               }
             end

--- a/app/models/option.rb
+++ b/app/models/option.rb
@@ -2,22 +2,24 @@
 #
 # Table name: options
 #
-#  id           :bigint           not null, primary key
-#  discarded_at :datetime
-#  group_en     :string
-#  group_es     :string
-#  group_pt     :string
-#  name_en      :string
-#  name_es      :string
-#  name_pt      :string
-#  next         :integer
-#  required     :boolean          default(FALSE)
-#  status_color :string
-#  type_option  :string
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  question_id  :bigint           not null
-#  resource_id  :integer
+#  id                    :bigint           not null, primary key
+#  disable_other_options :boolean          default(FALSE)
+#  discarded_at          :datetime
+#  group_en              :string
+#  group_es              :string
+#  group_pt              :string
+#  name_en               :string
+#  name_es               :string
+#  name_pt               :string
+#  next                  :integer
+#  required              :boolean          default(FALSE)
+#  status_color          :string
+#  type_option           :string
+#  value                 :string
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  question_id           :bigint           not null
+#  resource_id           :integer
 #
 # Indexes
 #

--- a/app/models/questionnaire.rb
+++ b/app/models/questionnaire.rb
@@ -13,6 +13,7 @@
 #
 class Questionnaire < ApplicationRecord
   include Discard::Model
+  default_scope -> { kept }
 
   has_many :questions
 end

--- a/db/files/questions.rb
+++ b/db/files/questions.rb
@@ -325,13 +325,13 @@ QUESTIONS_DATA = [
     resource_type: 'relation',
     next: 16,
     options: [
-      { name_es: 'Larvas', name_en: 'Larvae', name_pt: 'Larvas', next: 16,
+      { name_es: 'Larvas', name_en: 'Larvae', name_pt: 'Larvas', next: 16, group_es: 'Estadios', group_en: 'Stages', group_pt: 'Estágios',
         resource_id: TypeContent.find_by(name_es: 'Larvas').id, status_color: Constants::ContainerStatus::INFECTED },
-      { name_es: 'Pupas', name_en: 'Pupae', name_pt: 'Pupas', next: 16,
+      { name_es: 'Pupas', name_en: 'Pupae', name_pt: 'Pupas', next: 16, group_es: 'Estadios', group_en: 'Stages', group_pt: 'Estágios',
         resource_id: TypeContent.find_by(name_es: 'Pupas').id, status_color: Constants::ContainerStatus::INFECTED },
-      { name_es: 'Huevos', name_en: 'Eggs', name_pt: 'Ovos', next: 16,
+      { name_es: 'Huevos', name_en: 'Eggs', name_pt: 'Ovos', next: 16, group_es: 'Estadios', group_en: 'Stages', group_pt: 'Estágios',
         resource_id: TypeContent.find_by(name_es: 'Huevos').id, status_color: Constants::ContainerStatus::INFECTED },
-      { name_es: 'Nada', name_en: 'Nothing', name_pt: 'Nada', next: 16,
+      { name_es: 'Nada', name_en: 'Nothing', name_pt: 'Nada', next: 16, group_es: 'Nada', group_en: 'Nothing', group_pt: 'Nada',
         resource_id: TypeContent.find_by(name_es: 'Nada').id, disable_other_options: true }
     ]
   },

--- a/db/files/questions.rb
+++ b/db/files/questions.rb
@@ -70,7 +70,7 @@ unless SeedTask.find_by(task_name: 'add_type_contents_v1')
   TypeContent.create!(name_es: 'Larvas', name_en: 'Larvae', name_pt: 'Larvas')
   TypeContent.create!(name_es: 'Pupas', name_en: 'Pupae', name_pt: 'Pupas')
   TypeContent.create!(name_es: 'Huevos', name_en: 'Eggs', name_pt: 'Ovos')
-  TypeContent.create!(name_es: 'Nada', name_en: 'None', name_pt: 'Nada', disable_other_options: true)
+  TypeContent.create!(name_es: 'Nada', name_en: 'None', name_pt: 'Nada')
   SeedTask.create!(task_name: 'add_type_contents_v1')
 end
 

--- a/db/files/questions.rb
+++ b/db/files/questions.rb
@@ -70,7 +70,7 @@ unless SeedTask.find_by(task_name: 'add_type_contents_v1')
   TypeContent.create!(name_es: 'Larvas', name_en: 'Larvae', name_pt: 'Larvas')
   TypeContent.create!(name_es: 'Pupas', name_en: 'Pupae', name_pt: 'Pupas')
   TypeContent.create!(name_es: 'Huevos', name_en: 'Eggs', name_pt: 'Ovos')
-  TypeContent.create!(name_es: 'Nada', name_en: 'None', name_pt: 'Nada')
+  TypeContent.create!(name_es: 'Nada', name_en: 'None', name_pt: 'Nada', disable_other_options: true)
   SeedTask.create!(task_name: 'add_type_contents_v1')
 end
 
@@ -245,9 +245,9 @@ QUESTIONS_DATA = [
     resource_type: 'attribute',
     options: [
       { name_es: 'Sí, contiene agua', name_en: 'Yes, it holds water', name_pt: 'Sim, contém água', next: 12,
-        type_option: 'boolean'},
+        type_option: 'boolean', value: 1},
       { name_es: 'No, no contiene agua', name_en: 'No, it does not hold water', name_pt: 'Não, não contém água',
-        next: 20, type_option: 'boolean' }
+        next: 20, type_option: 'boolean', value: 0 }
     ]
   },
   {
@@ -332,7 +332,7 @@ QUESTIONS_DATA = [
       { name_es: 'Huevos', name_en: 'Eggs', name_pt: 'Ovos', next: 16,
         resource_id: TypeContent.find_by(name_es: 'Huevos').id, status_color: Constants::ContainerStatus::INFECTED },
       { name_es: 'Nada', name_en: 'Nothing', name_pt: 'Nada', next: 16,
-        resource_id: TypeContent.find_by(name_es: 'Nada').id }
+        resource_id: TypeContent.find_by(name_es: 'Nada').id, disable_other_options: true }
     ]
   },
   {

--- a/db/files/questions.rb
+++ b/db/files/questions.rb
@@ -77,9 +77,9 @@ end
 QUESTIONS_DATA = [
   {
     id: 1,
-    question_text_es: 'Me dieron permiso para visitar la casa ?',
-    question_text_en: '',
-    question_text_pt: '',
+    question_text_es: '¿Me dieron permiso para visitar la casa?',
+    question_text_en: 'Did they give me permission to visit the house?',
+    question_text_pt: 'Eles me deram permissão para visitar a casa?',
     type_field: 'list',
     resource_name: '',
     resource_type: 'attribute',
@@ -317,9 +317,9 @@ QUESTIONS_DATA = [
   },
   {
     id: 15,
-    question_text_es: 'En este contenedor hay........',
-    question_text_en: 'In this container there are........',
-    question_text_pt: 'Neste recipiente há........',
+    question_text_es: 'En este contenedor hay...',
+    question_text_en: 'In this container there are...',
+    question_text_pt: 'Neste recipiente há...',
     type_field: 'multiple',
     resource_name: 'type_content_id',
     resource_type: 'relation',
@@ -359,8 +359,8 @@ QUESTIONS_DATA = [
     resource_type: 'attribute',
     next: 18,
     options: [
-      { name_es: 'Si, si puedo', name_en: 'Yes, I can', name_pt: 'Sim', next: 18 },
-      { name_es: 'No, no no puedo', name_en: 'No, I cant', name_pt: 'No', next: 18 }
+      { name_es: 'Si, si puedo', name_en: 'Yes, I can', name_pt: 'Sim', next: 18, value: 0 },
+      { name_es: 'No, no no puedo', name_en: 'No, I cant', name_pt: 'No', next: 18, value: 1 }
     ]
   },
   {

--- a/db/migrate/20240923175211_add_value_and_disable_other_options_to_option.rb
+++ b/db/migrate/20240923175211_add_value_and_disable_other_options_to_option.rb
@@ -1,0 +1,6 @@
+class AddValueAndDisableOtherOptionsToOption < ActiveRecord::Migration[7.1]
+  def change
+    add_column :options, :value, :string
+    add_column :options, :disable_other_options, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -235,6 +235,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_25_091841) do
     t.string "group_pt"
     t.string "type_option"
     t.string "status_color"
+    t.string "value"
+    t.boolean "disable_other_options", default: false
     t.index ["question_id"], name: "index_options_on_question_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_20_183327) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_23_175211) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "unaccent"
@@ -235,6 +235,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_20_183327) do
     t.string "group_pt"
     t.string "type_option"
     t.string "status_color"
+    t.string "value"
+    t.boolean "disable_other_options", default: false
     t.index ["question_id"], name: "index_options_on_question_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -264,11 +264,11 @@ unless SeedTask.find_by(task_name: 'create_visit_params')
 end
 
 #create questions
-unless SeedTask.find_by(task_name: 'create_questions_v5')
+unless SeedTask.find_by(task_name: 'create_questions_v6')
 
   Option.destroy_all
   Question.destroy_all
-  Questionnaire.destroy_all
+  Questionnaire.discard_all
 
   images = get_images_for_questionnaire
 
@@ -290,16 +290,16 @@ unless SeedTask.find_by(task_name: 'create_questions_v5')
     end
   end
 
-  # images.each do |image|
-  #   resource = Question.find_by(question_text_es: image[:filename])
-  #   resource ||= Option.find_by(name_es: image[:filename])
-  #   next unless resource
-  #
-  #   resource.image.attach(image)
-  #   image[:io].unlink
-  # end
+  images.each do |image|
+    resource = Question.find_by(question_text_es: image[:filename])
+    resource ||= Option.find_by(name_es: image[:filename])
+    next unless resource
 
-  SeedTask.create!(task_name: 'create_questions_v5')
+    resource.image.attach(image)
+    image[:io].unlink
+  end
+
+  SeedTask.create!(task_name: 'create_questions_v6')
 
 end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -264,7 +264,7 @@ unless SeedTask.find_by(task_name: 'create_visit_params')
 end
 
 #create questions
-unless SeedTask.find_by(task_name: 'create_questions_v4')
+unless SeedTask.find_by(task_name: 'create_questions_v5')
 
   Option.destroy_all
   Question.destroy_all
@@ -299,7 +299,7 @@ unless SeedTask.find_by(task_name: 'create_questions_v4')
   #   image[:io].unlink
   # end
 
-  SeedTask.create!(task_name: 'create_questions_v4')
+  SeedTask.create!(task_name: 'create_questions_v5')
 
 end
 


### PR DESCRIPTION
This migration adds two new columns, `value` and `disable_other_options`, to the `options` table. Updated associated files and serializers to support these new attributes and reflect them in the schema. Also updated seed tasks and relevant models accordingly.