### PR TITLE
Add sector support for Wedges in serializers and queries

### DIFF
--- a/app/concepts/api/v1/wedges/contracts/index.rb
+++ b/app/concepts/api/v1/wedges/contracts/index.rb
@@ -12,6 +12,7 @@ module Api
             optional(:filter).maybe(:hash) do
               optional(:name).maybe(:string)
               optional(:neighborhood_id).maybe(:integer)
+              optional(:sector_id).maybe(:integer)
             end
 
             optional(:page).maybe(:hash) do

--- a/app/concepts/api/v1/wedges/queries/index.rb
+++ b/app/concepts/api/v1/wedges/queries/index.rb
@@ -22,6 +22,7 @@ module Api
             @model.where(discarded_at: nil)
                   .yield_self(&method(:name_clause))
                   .yield_self(&method(:neighborhood_clause))
+                  .yield_self(&method(:sector_id_clause))
                   .yield_self(&method(:sort_clause))
           end
 
@@ -57,6 +58,12 @@ module Api
             return relation if @params['neighborhood_id'].nil? || @params['neighborhood_id'].blank?
 
             relation.where( neighborhood_id: @params['neighborhood_id'] )
+          end
+
+          def sector_id_clause(relation)
+            return relation if @filter[:sector_id].nil? || @filter[:sector_id].blank?
+
+            relation.where( neighborhood_id: @filter[:sector_id] )
           end
 
           def sort_clause(relation)

--- a/app/concepts/api/v1/wedges/serializers/index.rb
+++ b/app/concepts/api/v1/wedges/serializers/index.rb
@@ -8,6 +8,15 @@ module Api
           set_type :wedge
 
           attributes :name
+
+          attribute :sector do |wedge|
+            next if wedge.sector.nil?
+
+            {
+              id: wedge.sector.id,
+              name: wedge.sector.name
+            }
+          end
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,6 +99,7 @@ Rails.application.routes.draw do
         get '/', to: 'cities#list_by_country_and_state_assumption', on: :collection
         get '/', to: 'cities#show_by_country_and_state_assumption', on: :member
       end
+      resources :wedges
 
       namespace :public do
         resources :countries, only: %i[show index] do


### PR DESCRIPTION
Extended serializers to include sector attributes for wedges and modified queries to filter by sector_id. Also updated routes to include wedges resources and contracts to support sector_id filtering.