### PR TITLE
Add permissions for changing team and update team serializer

### DIFF
--- a/app/concepts/api/v1/teams/serializers/show.rb
+++ b/app/concepts/api/v1/teams/serializers/show.rb
@@ -19,7 +19,13 @@ module Api
           end
 
           attribute :members do |brigade|
-            brigade.members.map { |user| { id: user.id, fullName: "#{user.first_name} #{user.last_name}" } }
+            brigade.members.map do |user|
+              {
+                id: user.id,
+                fullName: "#{user.first_name} #{user.last_name}",
+                rol: user.roles&.first&.name
+              }
+            end
           end
 
           attribute :organizations do |brigade|

--- a/app/concepts/api/v1/wedges/queries/index.rb
+++ b/app/concepts/api/v1/wedges/queries/index.rb
@@ -8,7 +8,7 @@ module Api
           include Api::V1::Lib::Queries::QueryHelper
 
           def initialize(filter, sort, params)
-            @model = Wedge
+            @model = Wedge.joins(:sector)
             @filter = filter
             @sort = sort
             @params = params
@@ -33,7 +33,7 @@ module Api
           def name_clause(relation)
             return relation if @filter.nil? || @filter[:name].blank?
 
-            relation.where('neighborhoods.name ilike :query', query: "%#{@filter[:name]}%")
+            relation.where('wedges.name ilike :query', query: "%#{@filter[:name]}%")
           end
 
           def country_clause(relation)
@@ -57,13 +57,13 @@ module Api
           def neighborhood_clause(relation)
             return relation if @params['neighborhood_id'].nil? || @params['neighborhood_id'].blank?
 
-            relation.where( neighborhood_id: @params['neighborhood_id'] )
+            relation.where(neighborhood_id: @params['neighborhood_id'])
           end
 
           def sector_id_clause(relation)
-            return relation if @filter[:sector_id].nil? || @filter[:sector_id].blank?
+            return relation if @filter.nil? || @filter[:sector_id].nil? || @filter[:sector_id].blank?
 
-            relation.where( neighborhood_id: @filter[:sector_id] )
+            relation.where(neighborhood_id: @filter[:sector_id])
           end
 
           def sort_clause(relation)

--- a/config/initializers/constants/error_codes.rb
+++ b/config/initializers/constants/error_codes.rb
@@ -59,7 +59,8 @@ module Constants
       not_found?: 54,
       user_account_locked?: 55,
       unexpected_key: 56,
-      without_permissions: 57
+      without_permissions: 57,
+      users_change_team: 58
     }.freeze
   end
 end

--- a/config/initializers/constants/permission_codes.rb
+++ b/config/initializers/constants/permission_codes.rb
@@ -88,7 +88,8 @@ module Constants
       neighborhoods_show: :neighborhoods_show,
       neighborhoods_create: :neighborhoods_create,
       neighborhoods_update: :neighborhoods_update,
-      neighborhoods_destroy: :neighborhoods_destroy
+      neighborhoods_destroy: :neighborhoods_destroy,
+      users_change_team: :users_change_team
     }.freeze
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -342,3 +342,11 @@ unless SeedTask.find_by(task_name: 'remove_content_type_from_params')
   vp.destroy if vp
   SeedTask.create(task_name: 'container_types')
 end
+
+
+unless SeedTask.find_by(task_name: 'permissions_for_change_brigade_v2')
+  roles = Role.where(name: %w[team_leader])
+  permission = Permission.find_or_create_by(name: 'change_team', resource: 'users')
+  roles.each {|rol| rol.permissions << permission}
+  SeedTask.create(task_name: 'permissions_for_change_brigade_v2')
+end


### PR DESCRIPTION
Introduced a new permission 'change_team' for team leaders and updated seed data to reflect this. Added 'users_change_team' error and permission codes. Enhanced the team serializer to include the user's role.