### PR TITLE
Add permissions for listing wedges

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -350,3 +350,12 @@ unless SeedTask.find_by(task_name: 'permissions_for_change_brigade_v2')
   roles.each {|rol| rol.permissions << permission}
   SeedTask.create(task_name: 'permissions_for_change_brigade_v2')
 end
+
+unless SeedTask.find_by(task_name: 'permissions_for_list_wedges')
+  roles = Role.where(name: %w[team_leader admin])
+  permission = Permission.find_or_create_by(name: 'index', resource: 'wedges')
+  roles.each do |role|
+    role.permissions << permission unless role.permissions.exists?(permission.id)
+  end
+  SeedTask.create(task_name: 'permissions_for_list_wedges')
+end


### PR DESCRIPTION
This commit adds a new seed task to assign the 'index' permission for the 'wedges' resource to 'team_leader' and 'admin' roles. It ensures the permission is created if it doesn't exist and only assigns it if not already present.