### PR TITLE
Fix name search query in index action

### DIFF
--- a/app/concepts/api/v1/wedges/queries/index.rb
+++ b/app/concepts/api/v1/wedges/queries/index.rb
@@ -32,8 +32,9 @@ module Api
 
           def name_clause(relation)
             return relation if @filter.nil? || @filter[:name].blank?
+            word_searched = CGI.unescape(@filter[:name])
 
-            relation.where('wedges.name ilike :query', query: "%#{@filter[:name]}%")
+            relation.where('wedges.name ilike :query', query: "%#{word_searched}%")
           end
 
           def country_clause(relation)


### PR DESCRIPTION
Unescaped the name filter parameter before using it in the search query to ensure user-provided strings are correctly interpreted. This adjustment ensures that names containing special characters are properly handled in the search functionality.