### PR TITLE
Add optional 'name' filter to house blocks contracts

### DIFF
--- a/app/concepts/api/v1/house_blocks/contracts/index.rb
+++ b/app/concepts/api/v1/house_blocks/contracts/index.rb
@@ -11,6 +11,7 @@ module Api
           params do
             optional(:filter).maybe(:hash) do
               optional(:wedge_id).maybe(:integer)
+              optional(:name).maybe(:string)
               optional(:team_id).maybe(:integer)
               optional(:user_profile_id).maybe(:integer)
             end


### PR DESCRIPTION
This commit introduces an optional 'name' filter to the parameters in house blocks contracts. This enhancement allows filtering by name in addition to existing parameters. It improves the flexibility and granularity of the API filters.