### PR TITLE
Add optional 'name' filter to house blocks contracts

### DIFF
--- a/app/concepts/api/v1/house_blocks/contracts/index.rb
+++ b/app/concepts/api/v1/house_blocks/contracts/index.rb
@@ -11,6 +11,7 @@ module Api
           params do
             optional(:filter).maybe(:hash) do
               optional(:wedge_id).maybe(:integer)
+              optional(:name).maybe(:string)
               optional(:team_id).maybe(:integer)
               optional(:user_profile_id).maybe(:integer)
             end

--- a/app/concepts/api/v1/wedges/queries/index.rb
+++ b/app/concepts/api/v1/wedges/queries/index.rb
@@ -32,8 +32,9 @@ module Api
 
           def name_clause(relation)
             return relation if @filter.nil? || @filter[:name].blank?
+            word_searched = CGI.unescape(@filter[:name])
 
-            relation.where('wedges.name ilike :query', query: "%#{@filter[:name]}%")
+            relation.where('wedges.name ilike :query', query: "%#{word_searched}%")
           end
 
           def country_clause(relation)


### PR DESCRIPTION


This commit introduces an optional 'name' filter to the parameters in house blocks contracts. This enhancement allows filtering by name in addition to existing parameters. It improves the flexibility and granularity of the API filters.
