### PR TITLE
Add update operations for posts and comments

### DIFF
--- a/app/concepts/api/v1/comments/contracts/update.rb
+++ b/app/concepts/api/v1/comments/contracts/update.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+require 'ostruct'
+
+module Api
+  module V1
+    module Comments
+      module Contracts
+        class Update < Dry::Validation::Contract
+
+          def self.kall(...)
+            new.call(...)
+          end
+
+          params do
+            required(:id).filled(:integer)
+            required(:post_id).filled(:integer)
+            optional(:user_account_id).filled(:integer)
+            optional(:content).filled(:string, min_size?: 5, max_size?: 500)
+            optional(:photo)
+            optional(:delete_photo).maybe(:bool)
+          end
+
+          rule(:id) do
+            unless Comment.find_by(id: values[:id])
+              key(:id).failure(text: 'The comment not exists', predicate: :not_found?)
+            end
+          end
+
+          rule(:user_account_id) do
+            unless UserAccount.find_by(id: values[:user_account_id])
+              key(:user_account_id).failure(text: 'the user not exist', predicate: :not_found?)
+            end
+          end
+
+          rule(:post_id) do
+            unless Post.find_by(id: values[:post_id])
+              key(:user_account_id).failure(text: 'the post not exist', predicate: :not_found?)
+            end
+          end
+
+          rule(:photo) do
+            if values && !values[:photo].nil? && !values[:photo].is_a?(ActionDispatch::Http::UploadedFile)
+              unless values[:photo].content_type.start_with?('image/')
+                key(:photo).failure(text: 'must be an image')
+              end
+
+              if values[:photo].size > 5_242_880
+                key(:photo).failure(text: 'is too big, must be less than 5MB',
+                                    predicate: :unique?)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/comments/operations/update.rb
+++ b/app/concepts/api/v1/comments/operations/update.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Comments
+      module Operations
+        class Update < ApplicationOperation
+          include Dry::Transaction
+
+          tee :params
+          step :validate_schema
+          tee :transform_params
+          tee :check_if_has_photo
+          step :update_comment
+
+          def params(input)
+            @ctx = {}
+            @params = to_snake_case(input[:params])
+            @current_user = input[:current_user]
+            @params.delete(:action)
+            @params.delete(:controller)
+            @params[:user_account_id] = @current_user.id
+          end
+
+          def validate_schema
+            @ctx['contract.default'] = Api::V1::Comments::Contracts::Update.kall(@params)
+            is_valid = @ctx['contract.default'].success?
+            return Success({ ctx: @ctx, type: :success }) if is_valid
+
+            Failure({ ctx: @ctx, type: :invalid })
+          end
+
+          def transform_params
+            @data = @ctx['contract.default'].values.data
+          end
+
+          def check_if_has_photo
+            @delete_photo = @data[:photo].nil? && @data[:delete_photo]
+            @photo  = @data[:photo] if !@data[:photo].blank?
+            @data.delete(:delete_photo)
+            @data.delete(:photo)
+          end
+
+          def update_comment
+            begin
+              comment = Comment.find_by(id: @data[:id])
+              comment = manage_photos(comment)
+              comment.update(@data)
+              @ctx[:model] = comment
+              return Success({ ctx: @ctx, type: :created })
+            rescue => error
+              errors = ErrorFormater.new_error(field: :base, msg: error, custom_predicate: :user_account_without_confirmation? )
+
+              return Failure({ ctx: @ctx, type: :invalid, errors: }) unless @ctx[:model]
+            end
+          end
+
+          def manage_photos(comment)
+            if @photo && !@delete_photo
+              comment.photo = @photo
+            end
+            if @delete_photo && !@has_photo
+              comment.photo.purge
+            end
+            comment
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/comments/serializers/show.rb
+++ b/app/concepts/api/v1/comments/serializers/show.rb
@@ -13,11 +13,11 @@ module Api
             comment.likes.count
           end
 
-          attribute :photos do |post|
-            next unless post.photo.attached?
+          attribute :photos do |comment|
+            next unless comment.photo.attached?
 
             {
-              photo_url: Rails.application.routes.url_helpers.url_for(post.photo)
+              photo_url: Rails.application.routes.url_helpers.url_for(comment.photo)
             }
           end
         end

--- a/app/concepts/api/v1/posts/contracts/update.rb
+++ b/app/concepts/api/v1/posts/contracts/update.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+require 'ostruct'
+
+module Api
+  module V1
+    module Posts
+      module Contracts
+        class Update < Dry::Validation::Contract
+
+          def self.kall(...)
+            new.call(...)
+          end
+
+          params do
+            required(:id).filled(:integer)
+            optional(:user_account_id).filled(:integer)
+            optional(:content).filled(:string, min_size?: 5, max_size?: 500)
+            optional(:photos).filled(:array)
+            optional(:delete_photo).maybe(:bool)
+          end
+
+          rule(:id) do
+            unless Post.find_by(id: values[:id])
+              key(:id).failure(text: 'The post not exists', predicate: :not_found?)
+            end
+          end
+
+          rule(:user_account_id) do
+            user = UserAccount.find_by(id: values[:user_account_id])
+
+            unless user
+              key(:user_account_id).failure(text: 'the user has not exist', predicate: :not_found?)
+            end
+
+            unless user&.teams&.any?
+              key(:user_account_id).failure(text: 'the user has no team assigned', predicate: :not_found?)
+            end
+
+            unless user&.city_id
+              key(:user_account_id).failure(text: 'the user has no city assigned', predicate: :not_found?)
+            end
+
+            unless user&.neighborhood_id
+              key(:user_account_id).failure(text: 'the user has no sector assigned', predicate: :not_found?)
+            end
+
+            if Neighborhood.find_by(id: user&.neighborhood_id)&.country.nil?
+              key(:user_account_id).failure(text: 'the user has no country assigned', predicate: :not_found?)
+            end
+
+          end
+
+          rule(:photos) do
+            if values[:photos]
+              unless values[:photos].all? { |photo| photo.content_type.start_with?('image/') }
+                key(:photos).failure(text: 'must be an image')
+              end
+
+              if values[:photos].size > 5
+                key(:photos).failure(text: 'cannot have more than 5 attachments',
+                                     predicate: :unique?)
+              end
+
+              values[:photos].each do |photo|
+                if photo.size > 5_242_880
+                  key(:photos).failure(text: 'is too big, must be less than 5MB',
+                                       predicate: :unique?)
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/posts/operations/update.rb
+++ b/app/concepts/api/v1/posts/operations/update.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Posts
+      module Operations
+        class Update < ApplicationOperation
+          include Dry::Transaction
+
+          tee :params
+          step :validate_schema
+          tee :transform_params
+          tee :check_if_has_photo
+          step :update_post
+
+          def params(input)
+            @ctx = {}
+            @params = to_snake_case(input[:params])
+            @current_user = input[:current_user]
+            @params.delete(:action)
+            @params.delete(:controller)
+            @params[:user_account_id] = @current_user.id
+          end
+
+          def validate_schema
+            @ctx['contract.default'] = Api::V1::Posts::Contracts::Update.kall(@params)
+            is_valid = @ctx['contract.default'].success?
+            return Success({ ctx: @ctx, type: :success }) if is_valid
+
+            Failure({ ctx: @ctx, type: :invalid })
+          end
+
+          def transform_params
+            @data = @ctx['contract.default'].values.data
+            @data[:team_id] = @current_user.teams.first.id
+            @data[:city_id] = @current_user.city_id
+            @data[:neighborhood_id] = @current_user.neighborhood_id
+            @data[:country_id] = Neighborhood.find_by(id: @data[:neighborhood_id]).country.id
+          end
+
+          def check_if_has_photo
+            @delete_photo = @data[:photos].nil? && @data[:delete_photo]
+            @photo  = @data[:photos] if !@data[:photos].blank?
+            @data.delete(:delete_photo)
+            @data.delete(:photos)
+          end
+
+          def update_post
+            begin
+              post = Post.find_by(id: @data[:id])
+              post = manage_photos(post)
+              post.update(@data)
+              @ctx[:model] = post
+              return Success({ ctx: @ctx, type: :created })
+            rescue => error
+              errors = ErrorFormater.new_error(field: :base, msg: error, custom_predicate: :user_account_without_confirmation? )
+
+              return Failure({ ctx: @ctx, type: :invalid, errors: }) unless @ctx[:model]
+            end
+          end
+
+          def manage_photos(post)
+            if @photo && !@delete_photo
+              post.photos = @photo
+            end
+            if @delete_photo && !@has_photo
+              post.photos.purge
+            end
+            post
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/api/v1/posts/serializers/show.rb
+++ b/app/concepts/api/v1/posts/serializers/show.rb
@@ -14,7 +14,7 @@ module Api
           end
 
           attribute :photos do |post|
-            next unless post.photos.attached?
+            next if post.photos.count < 1
 
             res = []
 

--- a/app/controllers/api/v1/comments_controller.rb
+++ b/app/controllers/api/v1/comments_controller.rb
@@ -19,6 +19,12 @@ module Api
                  options: { current_user: }
       end
 
+      def update
+        endpoint operation: Api::V1::Comments::Operations::Update,
+                 renderer_options: { serializer: Api::V1::Comments::Serializers::Show },
+                 options: { current_user: }
+      end
+
       def like
         endpoint operation: Api::V1::Comments::Operations::Like,
                  renderer_options: { serializer: Api::V1::Comments::Serializers::Show },

--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -22,6 +22,12 @@ module Api
                  options: { current_user: }
       end
 
+      def update
+        endpoint operation: Api::V1::Posts::Operations::Update,
+                 renderer_options: { serializer: Api::V1::Posts::Serializers::Show },
+                 options: { current_user: }
+      end
+
       def like
         endpoint operation: Api::V1::Posts::Operations::Like,
                  renderer_options: { serializer: Api::V1::Posts::Serializers::Show },

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,11 +52,11 @@ Rails.application.routes.draw do
           get :current
         end
       end
-      resources :posts, only: %i[create show index destroy] do
+      resources :posts do
         member do
           post 'like'
         end
-        resources :comments, only: %i[index create show destroy] do
+        resources :comments do
           member do
             post 'like'
           end


### PR DESCRIPTION
Implemented update contracts and operations for both posts and comments, enabling users to update their posts and comments. Adjusted the serializers to correctly handle photo attachments and modified routes to allow update actions.