### PR TITLE
Add created_by attribute to serializers

### DIFF
--- a/app/concepts/api/v1/comments/serializers/show.rb
+++ b/app/concepts/api/v1/comments/serializers/show.rb
@@ -16,6 +16,17 @@ module Api
           attribute :liked_by_me do |comment|
             comment.likes.exists?(user_account_id: comment.user_account_id)
           end
+
+          attribute :created_by do |comment|
+            next if comment.user_account_id.blank?
+
+            {
+              accountId: comment.user_account_id,
+              userName: comment.user_account.first_name,
+              lastName: comment.user_account.last_name,
+            }
+          end
+
           attribute :photos do |comment|
             next unless comment.photo.attached?
 

--- a/app/concepts/api/v1/posts/serializers/index.rb
+++ b/app/concepts/api/v1/posts/serializers/index.rb
@@ -21,6 +21,16 @@ module Api
             post.user_account_id
           end
 
+          attribute :create_by_user do |post|
+            next if post.user_account_id.blank?
+
+            {
+              accountId: post.user_account_id,
+              userName: post.user_account.first_name,
+              lastName: post.user_account.last_name,
+            }
+          end
+
           attribute :createdBy do |post|
             next unless post.user_account_id
 

--- a/app/concepts/api/v1/posts/serializers/show.rb
+++ b/app/concepts/api/v1/posts/serializers/show.rb
@@ -13,8 +13,19 @@ module Api
             post.likes.size  # use `size` instead of `count` after preloading `likes`
           end
 
+
           attribute :like_by_me do |post|
             post.likes.any? { |like| like.user_account_id == post.user_account_id }  # use `any?` instead of `exists?` after preloading `likes`
+          end
+
+          attribute :created_by do |post|
+            next if post.user_account_id.blank?
+
+            {
+              accountId: post.user_account_id,
+              userName: post.user_account.first_name,
+              lastName: post.user_account.last_name,
+            }
           end
 
           attribute :photos do |post|

--- a/db/files/questions.rb
+++ b/db/files/questions.rb
@@ -218,6 +218,12 @@ QUESTIONS_DATA = [
     resource_type: 'relation',
     next: 11,
     options: [
+      { group_es: 'No permanentes', group_en: 'Non permanent', group_pt: 'Não permanente', name_es: 'Llanta',
+        name_en: 'Tire', name_pt: 'Pneu', resource_id: BreedingSiteType.find_by(name: 'Llanta').id },
+      { group_es: 'No permanentes', group_en: 'Non permanent', group_pt: 'Não permanente',
+        name_es: 'Elementos naturales', name_en: 'Natural elements', name_pt: 'Elementos naturais', resource_id: BreedingSiteType.find_by(name: 'Elementos naturales').id },
+      { group_es: 'No permanentes', group_en: 'Non permanent', group_pt: 'Não permanente', name_es: 'Otros',
+        name_en: 'Others', name_pt: 'Outros', resource_id: BreedingSiteType.find_by(name: 'Otros').id },
       { group_es: 'Permanentes', group_en: 'Permanent', group_pt: 'Permanentes', name_es: 'Tanques (cemento, polietileno, metal, otro material)',
         name_en: 'Tanks (cement, polyethylene, metal, other material)', name_pt: 'Tanques (cimento, polietileno, metal, outro material)', resource_id: BreedingSiteType.find_by(name: 'Tanques (cemento, polietileno, metal, otro material)').id },
       { group_es: 'Permanentes', group_en: 'Permanent', group_pt: 'Permanentes', name_es: 'Bidones o cilindros (metal, plástico)', name_en: 'Drums or cylinders (metal, plastic)',
@@ -226,13 +232,6 @@ QUESTIONS_DATA = [
         name_pt: 'Poços', resource_id: BreedingSiteType.find_by(name: 'Pozos').id },
       { group_es: 'Permanentes', group_en: 'Permanent', group_pt: 'Permanentes', name_es: 'Estructura o partes de la casa', name_en: 'Structure or parts of the house',
         name_pt: 'Estrutura ou partes da casa', resource_id: BreedingSiteType.find_by(name: 'Estructura o partes de la casa').id },
-      { group_es: 'No permanentes', group_en: 'Non permanent', group_pt: 'Não permanente', name_es: 'Llanta',
-        name_en: 'Tire', name_pt: 'Pneu', resource_id: BreedingSiteType.find_by(name: 'Llanta').id },
-      { group_es: 'No permanentes', group_en: 'Non permanent', group_pt: 'Não permanente',
-        name_es: 'Elementos naturales', name_en: 'Natural elements', name_pt: 'Elementos naturais', resource_id: BreedingSiteType.find_by(name: 'Elementos naturales').id },
-      { group_es: 'No permanentes', group_en: 'Non permanent', group_pt: 'Não permanente', name_es: 'Otros',
-        name_en: 'Others', name_pt: 'Outros', resource_id: BreedingSiteType.find_by(name: 'Otros').id }
-
     ]
   },
   {


### PR DESCRIPTION
This update adds a created_by attribute to the comment and post serializers, which includes user account details such as account ID, first name, and last name. This enhancement aims to provide more detailed user information within the serialized objects for comments and posts.