### PR TITLE
Set default Latitude and Longitude for new houses without location information

### DIFF
--- a/app/concepts/api/v1/visits/contracts/house.rb
+++ b/app/concepts/api/v1/visits/contracts/house.rb
@@ -7,8 +7,8 @@ module Api
         class House < Dry::Validation::Contract
           params do
             required(:address).filled(:string)
-            required(:latitude).filled(:float)
-            required(:longitude).filled(:float)
+            optional(:latitude).filled(:float)
+            optional(:longitude).filled(:float)
             optional(:notes).filled(:string)
             optional(:reference_code).filled(:string)
             required(:house_block_id).filled(:integer)

--- a/app/concepts/api/v1/visits/operations/create.rb
+++ b/app/concepts/api/v1/visits/operations/create.rb
@@ -74,7 +74,7 @@ module Api
           end
 
           def add_team
-            return  Success({ ctx: @ctx, type: :success }) if @params[:team_id]&.present?
+            return Success({ ctx: @ctx, type: :success }) if @params[:team_id]&.present?
             return nil unless @current_user.teams.any?
 
             @params[:team_id] = @current_user.teams.first.id
@@ -173,6 +173,9 @@ module Api
             team =  @current_user.teams&.first
             user_profile = @current_user.user_profile
             reference_code = generate_code(country, state, city, wedge, house_block)
+            location_status = @house_info[:latitude] && @house_info[:longitude] ? 'with_coordinates' : 'without_coordinates'
+            @house_info[:latitude] = @house_info[:latitude] || -3.775520
+            @house_info[:longitude] = @house_info[:longitude] || -73.450878
 
             @house_info[:country_id] = country.id
             @house_info[:state_id] = state.id
@@ -183,9 +186,11 @@ module Api
             @house_info[:team_id] = team.id
             @house_info[:user_profile_id] = user_profile.id
             @house_info[:reference_code] = reference_code
+            @house_info[:location_status] = location_status
 
 
-            @house = House.create(@house_info).id
+            @house = House.create!(@house_info)
+            @house.id
           end
 
           def update_house_status

--- a/app/concepts/api/v1/visits/services/house_finder_by_coords_service.rb
+++ b/app/concepts/api/v1/visits/services/house_finder_by_coords_service.rb
@@ -9,9 +9,8 @@ module Api
           DISTANCE = 30
 
           def self.find_similar_house(latitude:, longitude:, house_block_id:)
-            raise ArgumentError, 'latitude cannot be nil' if latitude.nil?
-            raise ArgumentError, 'longitude cannot be nil' if longitude.nil?
             raise ArgumentError, 'house_block_id cannot be nil' if house_block_id.nil?
+            return nil if latitude.nil? || longitude.nil?
 
             House.where(house_block_id:).find_each do |house|
               distance = get_distance(latitude, longitude, house.latitude, house.longitude)

--- a/app/models/house.rb
+++ b/app/models/house.rb
@@ -10,6 +10,7 @@
 #  infected_containers     :integer
 #  last_visit              :datetime
 #  latitude                :float
+#  location_status         :string
 #  longitude               :float
 #  non_infected_containers :integer
 #  notes                   :string

--- a/db/migrate/20241004021912_add_house_location_status_to_house.rb
+++ b/db/migrate/20241004021912_add_house_location_status_to_house.rb
@@ -1,0 +1,5 @@
+class AddHouseLocationStatusToHouse < ActiveRecord::Migration[7.1]
+  def change
+    add_column :houses, :location_status, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_04_015238) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_04_021912) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "unaccent"
@@ -173,6 +173,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_04_015238) do
     t.integer "infected_containers"
     t.integer "non_infected_containers"
     t.integer "potential_containers"
+    t.string "location_status"
     t.index ["city_id"], name: "index_houses_on_city_id"
     t.index ["country_id"], name: "index_houses_on_country_id"
     t.index ["house_block_id"], name: "index_houses_on_house_block_id"


### PR DESCRIPTION
Added the ability to save a house with a default coordinate and added a new attribute to house, the new attribute is for recognize the houses without coordinates.