### PR TITLE
feat: Last question static in FE

### DIFF
--- a/db/files/questions.rb
+++ b/db/files/questions.rb
@@ -428,17 +428,4 @@ QUESTIONS_DATA = [
         resource_id: EliminationMethodType.find_by(name_es: 'Otro'), type_option: 'textArea' },
     ]
   },
-  {
-    id: 20,
-    question_text_es: '¿Registrar otro contenedor?',
-    question_text_en: '¿Register another container?',
-    question_text_pt: '¿Registrar outro contêiner?',
-    type_field: 'list',
-    resource_name: '',
-    resource_type: 'attribute',
-    options: [
-      { name_es: 'Sí, registrar', name_en: 'Yes, register', name_pt: 'Sim, registrar', next: 10 },
-      { name_es: 'No, no es necesario', name_pt: 'Não, não é necessário', name_en: "No, it's not necessary", next: -1 }
-    ]
-  }
 ].freeze

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -276,7 +276,7 @@ unless SeedTask.find_by(task_name: 'create_questions_v6')
     name: 'Cuestionario de Zancudos',
     current_form: true,
     initial_question: 1,
-    final_question: 20
+    final_question: 19
   )
 
   QUESTIONS_DATA.each do |question_data|


### PR DESCRIPTION
This PR removes the "Add new container" question, in order to have it static on the FE for easier flow control.
- Removes last question
- Updates `final_question`