### PR TITLE
Crontab for sync databases between denguechatplus and GIS

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,6 +2,11 @@
 
 Sidekiq.configure_server do |config|
   config.redis = { url: ENV.fetch('REDIS_URL', 'redis://127.0.0.1:6379/0') }
+
+  config.on(:startup) do
+    Sidekiq.schedule = YAML.load_file( YAML.load_file(File.expand_path('../config/sidekiq.yml', __FILE__)))
+    SidekiqScheduler::Scheduler.instance.reload_schedule!
+  end
 end
 
 Sidekiq.configure_client do |config|

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -8,7 +8,7 @@
     :listened_queues_only: true
     :schedule:
         sync_houses_job:
-            cron: '0 1 * * 0'
+            cron: '30 14 * * 1'
             class: Houses::SyncHouses
             queue: default
             enabled: true


### PR DESCRIPTION
re-active the crontab for sync databases between denguechatplus and GIS(berkeley)