### PR TITLE
re-active the crontab for sync databases

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -8,7 +8,7 @@
     :listened_queues_only: true
     :schedule:
         sync_houses_job:
-            cron: '30 14 * * 1'
+            cron: '40 14 * * 1'
             class: Houses::SyncHouses
             queue: default
             enabled: true


### PR DESCRIPTION
re-active the crontab for sync databases between denguechatplus and GIS(berkeley)