### PR TITLE
re-active the crontab for sync database

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -4,7 +4,7 @@ Sidekiq.configure_server do |config|
   config.redis = { url: ENV.fetch('REDIS_URL', 'redis://127.0.0.1:6379/0') }
 
   config.on(:startup) do
-    Sidekiq.schedule = YAML.load_file( YAML.load_file(File.expand_path('../config/sidekiq.yml', __FILE__)))
+    Sidekiq.schedule = YAML.load_file(File.expand_path('../initializers/sidekiq.yml', File.dirname(__FILE__)))
     SidekiqScheduler::Scheduler.instance.reload_schedule!
   end
 end

--- a/config/initializers/sidekiq.yml
+++ b/config/initializers/sidekiq.yml
@@ -1,0 +1,4 @@
+Houses::SyncHouses:
+  description: "Sync houses every Sunday at 01:00 AM"
+  cron: "0 1 * * 0"
+  queue: default

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -4,14 +4,5 @@
 :queues:
     - default
     - mailers
-:scheduler:
-    :listened_queues_only: true
-    :schedule:
-        sync_houses_job:
-            cron: '40 14 * * 1'
-            class: Houses::SyncHouses
-            queue: default
-            enabled: true
-            description: "Sync houses every Sunday at 01:00 AM"
 production:
     :concurrency: 20


### PR DESCRIPTION
re-active the crontab for sync databases between denguechatplus and GIS(berkeley)