### PR TITLE
feature: Currently, a user account is locked after 5 failed login att…

### DIFF
--- a/app/concepts/api/v1/house_blocks/operations/update.rb
+++ b/app/concepts/api/v1/house_blocks/operations/update.rb
@@ -37,6 +37,7 @@ module Api
               begin
                 @ctx[:model] = HouseBlock.find_by(id: @data[:id])
                 update_houses!(@house_ids) if @house_ids.present?
+                @ctx[:model].update!(@ctx['contract.default'].values.data)
                 Success({ ctx: @ctx, type: :created })
               rescue ActiveRecord::RecordInvalid => e
                 errors = ErrorFormater.new_error(field: :base, msg: e.message, custom_predicate: :user_account_without_confirmation?)

--- a/app/models/house_block.rb
+++ b/app/models/house_block.rb
@@ -31,5 +31,5 @@ class HouseBlock < ApplicationRecord
 
   has_many :user_profile_house_blocks
   has_many :brigadists, class_name: 'UserProfile', through: :user_profile_house_blocks, source: :user_profile
-  belongs_to :neighborhood
+  belongs_to :neighborhood, optional: true
 end


### PR DESCRIPTION
…empts. We need to increase this limit to 10 attempts before triggering the account lock. This requires a backend change to update the login attempt threshold.