### PR TITLE
fix: Sort the list alphabetically.

### DIFF
--- a/app/concepts/api/v1/houses/operations/list_to_visit.rb
+++ b/app/concepts/api/v1/houses/operations/list_to_visit.rb
@@ -45,6 +45,7 @@ module Api
           end
 
           def paginate
+            @params["page"] = {"number"=>"1", "size"=>"1000000"}
             @pagy = Api::V1::Lib::Paginates::Paginate.kall(ctx: @ctx, model: @ctx[:data], params: @params.slice("page"))
             Success({ ctx: @ctx, type: :success })
           end


### PR DESCRIPTION
     Remove pagination, ensuring that all houses are listed, as a Frente a Frente does not typically contain a large number of houses.