### PR TITLE
Update the business logic to include a new boolean parameter called tariki_point_same_date

### DIFF
--- a/app/concepts/api/v1/inspections/operations/update.rb
+++ b/app/concepts/api/v1/inspections/operations/update.rb
@@ -84,7 +84,7 @@ module Api
                           "green"
                         end
               }
-              result[:tariki_status] = @house.is_tariki?
+              result[:tariki_status] = @house.is_tariki?(colors[result[:status]])
               @house.update!(result)
               @visit.update!(status: colors[result[:status]])
             elsif @inspections.empty? && @visit.visit_permission

--- a/app/concepts/api/v1/points/services/transactions.rb
+++ b/app/concepts/api/v1/points/services/transactions.rb
@@ -21,9 +21,11 @@ module Api
               return
             end
 
-            existing_points =  earner.points.where(house_id:).where("DATE(created_at)::date = ?::date", Date.current)&.first
+            unless AppConfigParam.find_by(name: 'tariki_point_same_date', value: 1)
+              existing_points = earner.points.where(house_id:).where("DATE(created_at)::date = ?::date", Date.current)&.first
 
-            return if existing_points
+              return if existing_points
+            end
 
             self.assign_by_earner(earner: user_account, house_id:, visit_id:)
 

--- a/app/concepts/api/v1/visits/operations/create.rb
+++ b/app/concepts/api/v1/visits/operations/create.rb
@@ -262,7 +262,7 @@ module Api
                           'green'
                         end
               }
-              result[:tariki_status] = @house.is_tariki?
+              result[:tariki_status] = @house.is_tariki?(colors[result[:status]])
               @house.update!(result)
               @ctx[:model].update!(status: colors[result[:status]])
               elsif inspections_ids.empty? && @params[:visit_permission]

--- a/app/concepts/api/v1/visits/operations/update.rb
+++ b/app/concepts/api/v1/visits/operations/update.rb
@@ -92,7 +92,7 @@ module Api
                           "green"
                         end
               }
-              result[:tariki_status] = @house.is_tariki?
+              result[:tariki_status] = @house.is_tariki?(colors[result[:status]])
               @house.update!(result)
               @ctx[:model].update!(status: colors[result[:status]])
             else

--- a/app/models/house.rb
+++ b/app/models/house.rb
@@ -78,7 +78,8 @@ class House < ApplicationRecord
   after_commit :update_consecutive_green_status
 
 
-  def is_tariki?
+  def is_tariki?(status_on_memory = nil)
+    status = status_on_memory || status
     return false unless status == 'green'
 
     min_consecutive_green = AppConfigParam.find_by(name: 'consecutive_green_statuses_for_tariki_house')&.value.to_i

--- a/db/migrate/20250416170101_create_param_for_tariki_point.rb
+++ b/db/migrate/20250416170101_create_param_for_tariki_point.rb
@@ -1,0 +1,9 @@
+class CreateParamForTarikiPoint < ActiveRecord::Migration[7.1]
+  def change
+    value = Rails.env.development? ? 1 : 0
+    AppConfigParam.find_or_create_by(name: 'tariki_point_same_date',param_type: 'boolean',
+                                     param_source: 'AppConfigParam',
+                                     value: value,
+                                     description: 'If tariki_point_same_date = true, all visits on the same day will be counted toward the total required to mark a house as tariki.')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_04_07_152610) do
+ActiveRecord::Schema[7.1].define(version: 2025_04_16_170101) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "unaccent"


### PR DESCRIPTION

If tariki_point_same_date = true, all visits on the same day will be counted toward the total required to mark a house as tariki.

If tariki_point_same_date = false, visits occurring on the same day will not be counted multiple times toward the tariki threshold.