### PR TITLE
The first option of the water source question is updated to:

### DIFF
--- a/db/migrate/20250530034811_modify_option_text_from_options.rb
+++ b/db/migrate/20250530034811_modify_option_text_from_options.rb
@@ -1,0 +1,10 @@
+class ModifyOptionTextFromOptions < ActiveRecord::Migration[7.1]
+  def change
+    option= Option.find_by(name_es: 'Agua del grifo o potable')
+    if option
+      option.name_es = 'Del grifo o de otro recipiente'
+      option.name_en = 'From the faucet or from another container'
+      option.save!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_05_30_033851) do
+ActiveRecord::Schema[7.1].define(version: 2025_05_30_034811) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "unaccent"


### PR DESCRIPTION
    Spanish: "Del grifo o de otro recipiente"

    English: "From the faucet or from another container"