### PR TITLE
change term recipiente by envase

### DIFF
--- a/db/migrate/20250530054553_replace_recipiente_envase_in_questions.rb
+++ b/db/migrate/20250530054553_replace_recipiente_envase_in_questions.rb
@@ -1,0 +1,60 @@
+class ReplaceRecipienteEnvaseInQuestions < ActiveRecord::Migration[7.1]
+  def up
+    question = Question.find_by(question_text_es: '¿Me dieron permiso para visitar la casa?')
+    question.next = 3
+    question.save!
+
+    execute <<~SQL
+      UPDATE questions
+      SET question_text_es = REPLACE(question_text_es, 'recipientes/envases', 'envases')
+      WHERE question_text_es ILIKE '%recipientes/envases%';
+    SQL
+
+    execute <<~SQL
+      UPDATE questions
+      SET question_text_es = REPLACE(question_text_es, 'recipiente/envase', 'envase')
+      WHERE question_text_es ILIKE '%recipiente/envase%';
+    SQL
+
+
+    execute <<~SQL
+      UPDATE options
+      SET name_es = REPLACE(name_es, 'recipientes/envases', 'envases')
+      WHERE name_es ILIKE '%recipientes/envases%';
+    SQL
+
+    execute <<~SQL
+      UPDATE options
+      SET name_es = REPLACE(name_es, 'recipiente/envase', 'envase')
+      WHERE name_es ILIKE '%recipiente/envase%';
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      UPDATE questions
+      SET question_text_es = REPLACE(question_text_es, 'envases', 'recipientes/envases')
+      WHERE question_text_es ILIKE '%envases%';
+    SQL
+
+    execute <<~SQL
+      UPDATE questions
+      SET question_text_es = REPLACE(question_text_es, 'envase', 'recipiente/envase')
+      WHERE question_text_es ILIKE '%envase%';
+    SQL
+
+
+    execute <<~SQL
+      UPDATE options
+      SET name_es = REPLACE(name_es, 'envases', 'recipientes/envases')
+      WHERE name_es ILIKE '%envases%';
+    SQL
+
+    execute <<~SQL
+      UPDATE options
+      SET name_es = REPLACE(name_es, 'envase', 'recipiente/envase')
+      WHERE name_es ILIKE '%envase%';
+    SQL
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_05_30_051229) do
+ActiveRecord::Schema[7.1].define(version: 2025_05_30_054553) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "unaccent"


### PR DESCRIPTION
The term “recipiente/envase” is currently used across multiple views …in the application. This phrasing is inconsistent and should be standardized to simply “envase” for clarity. Additionally, the English and Portuguese translations must be updated accordingly