### PR TITLE
change the term “recipiente/envase” by envase

### DIFF
--- a/db/migrate/20250530060817_modify_term_recipiente_in_descritpion_options.rb
+++ b/db/migrate/20250530060817_modify_term_recipiente_in_descritpion_options.rb
@@ -1,0 +1,55 @@
+class ModifyTermRecipienteInDescritpionOptions < ActiveRecord::Migration[7.1]
+  def up
+
+    execute <<~SQL
+      UPDATE questions
+      SET description_es = REPLACE(description_es, 'recipientes/envases', 'envases')
+      WHERE description_es ILIKE '%recipientes/envases%';
+    SQL
+
+    execute <<~SQL
+      UPDATE questions
+      SET description_es = REPLACE(description_es, 'recipiente/envase', 'envase')
+      WHERE description_es ILIKE '%recipiente/envase%';
+    SQL
+
+    execute <<~SQL
+      UPDATE questions
+      SET description_es = REPLACE(description_es, 'recipientes', 'envases')
+      WHERE description_es ILIKE '%recipientes%';
+    SQL
+
+    execute <<~SQL
+      UPDATE questions
+      SET description_es = REPLACE(description_es, 'recipiente', 'envase')
+      WHERE description_es ILIKE '%recipiente%';
+    SQL
+
+
+
+    execute <<~SQL
+      UPDATE options
+      SET name_es = REPLACE(name_es, 'recipientes/envases', 'envases')
+      WHERE name_es ILIKE '%recipientes/envases%';
+    SQL
+
+    execute <<~SQL
+      UPDATE options
+      SET name_es = REPLACE(name_es, 'recipiente/envase', 'envase')
+      WHERE name_es ILIKE '%recipiente/envase%';
+    SQL
+
+    execute <<~SQL
+      UPDATE options
+      SET name_es = REPLACE(name_es, 'recipiente', 'envase')
+      WHERE name_es ILIKE '%recipiente%';
+    SQL
+
+    execute <<~SQL
+      UPDATE options
+      SET name_es = REPLACE(name_es, 'recipientes', 'envases')
+      WHERE name_es ILIKE '%recipientes%';
+    SQL
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_05_30_054553) do
+ActiveRecord::Schema[7.1].define(version: 2025_05_30_060817) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "unaccent"


### PR DESCRIPTION
The term “recipiente/envase” is currently used across multiple views in the application. This phrasing is inconsistent and should be standardized to simply “envase” for clarity. Additionally, the English and Portuguese translations must be updated accordingly