### PR TITLE
House statuses when we dont have permissions

### DIFF
--- a/app/concepts/api/v1/visits/operations/create.rb
+++ b/app/concepts/api/v1/visits/operations/create.rb
@@ -285,8 +285,8 @@ module Api
             else
               @house.update!(infected_containers: 0, potential_containers: 0,
                              non_infected_containers: 0, last_visit:  @params[:visited_at] || Time.now.utc,
-                             status: 'red')
-              @ctx[:model].update!(status: 'Rojo')
+                             status: 'yellow')
+              @ctx[:model].update!(status: 'Amarillo')
             end
           end
 


### PR DESCRIPTION
Currently, when a house cannot be visited due to lack of permission the system assigns a Red status by default. This does not reflect the actual condition of the site, as no data could be collected. The correct behavior should be to assign Yellow in such cases.