### PR TITLE
rename "Otro (tratamiento manual)" water-source option to "Otro"

### DIFF
--- a/app/concepts/api/v1/visits/operations/bulk_upload.rb
+++ b/app/concepts/api/v1/visits/operations/bulk_upload.rb
@@ -56,7 +56,7 @@ module Api
               'Del grifo o de otro envase',
               'Agua activamente recogida. Ejemplo: canaleta, gotera, techo.',
               'Agua pasivamente recogida. Ejemplo: la lluvia lo llenó.',
-              'Otro (tratamiento manual)'
+              'Otro'
             ].freeze
             CONTAINER_PROTECTION = [
               'Sí, tiene tapa y está bien cerrado',
@@ -78,6 +78,10 @@ module Api
               'Otro'
             ].freeze
           end
+
+          LEGACY_CONTAINERS_OPTION_HEADER_ALIASES = {
+            'Otro (tratamiento manual)' => 'Otro'
+          }.freeze
 
           VISITS_HEADER_STRUCTURE = [
             # First row
@@ -308,7 +312,9 @@ module Api
             end
 
             containers_questions_headers = containers_sheet.row(1)
-            containers_options_headers = containers_sheet.row(2)
+            containers_options_headers = containers_sheet.row(2).map do |cell|
+              LEGACY_CONTAINERS_OPTION_HEADER_ALIASES[cell] || cell
+            end
             containers_headers = [containers_questions_headers, containers_options_headers]
 
             unless containers_headers == CONTAINERS_HEADER_STRUCTURE

--- a/lib/tasks/data_migration.rake
+++ b/lib/tasks/data_migration.rake
@@ -1,25 +1,9 @@
 # frozen_string_literal: true
 
 namespace :data_migration do
-  desc "Reorders the options of the question about the container content to it's proper order"
-  task fix_container_content_options_order: :environment do
-    options = Question.find_by(question_text_es: 'En este envase hay..').options
-
-    position_by_name = {
-      'Huevos' => 1,
-      'Larvas' => 2,
-      'Pupas' => 3,
-      'Nada' => 4,
-      'No pude revisar el envase' => 5
-    }
-
-    Option.transaction do
-      options.each do |option|
-        new_position = position_by_name[option.name_es]
-        next unless new_position
-
-        option.update!(position: new_position)
-      end
-    end
+  desc 'Renames the label of the option "Otro (tratamiento manual)" to just "Otro"'
+  task rename_option: :environment do
+    Option.find_by!(name_es: 'Otro (tratamiento manual)')
+          .update!(name_es: 'Otro', name_en: 'Other', name_pt: 'Outro')
   end
 end


### PR DESCRIPTION
## Summary

- Adds a `data_migration:rename_option` rake task that renames the water-source `Option` record in the DB: `name_es` `Otro (tratamiento manual)` → `Otro` (and English/Portuguese equivalents).
- Keeps the visits bulk-upload Excel flow backwards-compatible so brigadists can keep using their existing templates.
