### PR TITLE
fix: bulk upload row number pointing to wrong sheet row

### DIFF
--- a/app/concepts/api/v1/visits/operations/bulk_upload.rb
+++ b/app/concepts/api/v1/visits/operations/bulk_upload.rb
@@ -388,14 +388,13 @@ module Api
           def validate_rows(input) # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/MethodLength,Metrics/PerceivedComplexity
             visits_sheet, containers_sheet = input[:sheets]
             visits_headers, containers_headers = input[:headers]
-            header_offsets = { visits: visits_headers.size, containers: containers_headers.size }
             questionnaire = input[:questionnaire]
             questions = questionnaire.questions
 
             errors = []
 
-            visits_rows = get_rows(visits_sheet, header_offsets[:visits])
-            containers_rows = get_rows(containers_sheet, header_offsets[:containers])
+            visits_rows = get_rows(visits_sheet, visits_headers.size)
+            containers_rows = get_rows(containers_sheet, containers_headers.size)
 
             if visits_rows.empty? && containers_rows.empty?
               errors += ErrorFormater.new_error(
@@ -412,8 +411,9 @@ module Api
             visit_permission_other_option = visit_permission_options_raw.find_by!(type_option: 'textArea').name_es
             visit_permission_yes_option = visit_permission_options_raw.find_by!(value: '1').name_es
 
-            structured_visits_rows = visits_rows.map do |row|
+            structured_visits_rows = visits_rows.map do |row_number, row|
               {
+                row_number:,
                 site_code: row[0],
                 date: row[1],
                 brigadist: row[2],
@@ -425,8 +425,8 @@ module Api
               }
             end
 
-            structured_visits_rows.each_with_index do |row, index| # rubocop:disable Metrics/BlockLength
-              row_number = header_offsets[:visits] + 1 + index
+            structured_visits_rows.each do |row| # rubocop:disable Metrics/BlockLength
+              row_number = row[:row_number]
 
               if row[:site_code].present?
                 if row[:site_code].is_a?(String)
@@ -612,8 +612,9 @@ module Api
             breeding_site_type_options = questions.find_by!(question_text_es: ContainersHeaderQuestion::BREEDING_SITE_TYPE).options.pluck(:name_es)
             was_chemically_treated_options = questions.find_by!(question_text_es: ContainersHeaderQuestion::WAS_CHEMICALLY_TREATED).options.pluck(:name_es)
 
-            structured_containers_rows = containers_rows.map do |row|
+            structured_containers_rows = containers_rows.map do |row_number, row|
               {
+                row_number:,
                 site_code: row[0],
                 location: row[1],
                 breeding_site_type: row[2],
@@ -625,8 +626,8 @@ module Api
               }
             end
 
-            structured_containers_rows.each_with_index do |row, index| # rubocop:disable Metrics/BlockLength
-              row_number = header_offsets[:containers] + 1 + index
+            structured_containers_rows.each do |row| # rubocop:disable Metrics/BlockLength
+              row_number = row[:row_number]
 
               if row[:site_code].present?
                 if row[:site_code].is_a?(String)
@@ -963,7 +964,7 @@ module Api
               row = sheet.row(r)
               next if row.compact_blank.empty?
 
-              rows << row
+              rows << [r, row]
             end
 
             rows


### PR DESCRIPTION
## Summary
- `get_rows` silently drops blank rows from the sheet, but the index-based `row_number` calculation in `validate_rows` assumed rows were sequential, so every error message below a blank row drifted off the real sheet row.
- `get_rows` now emits `[sheet_row_number, row]` pairs and the actual sheet row is carried through to the structured hash, so error messages point to the correct "Fila".