### PR TITLE
Update Docker Ruby to 3.2.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1
 
 # Make sure RUBY_VERSION matches the Ruby version in .ruby-version and Gemfile
-ARG RUBY_VERSION=3.1.2
+ARG RUBY_VERSION=3.2.8
 FROM registry.docker.com/library/ruby:$RUBY_VERSION-slim as base
 
 # Rails app lives here


### PR DESCRIPTION
## Summary

- Update the Docker build's `RUBY_VERSION` from 3.1.2 to 3.2.8.
- Align the container runtime with `.ruby-version`, `Gemfile`, and `Gemfile.lock`.

## Why

The Dockerfile still selected Ruby 3.1.2 while Bundler requires Ruby 3.2.8. This mismatch can prevent dependency installation and application builds inside the container.

## Impact

Docker builds now use the Ruby version already required by the application. There are no application-code or dependency changes.

## Validation

- `git diff --check`
- Verified the Dockerfile version matches `.ruby-version`.
- `docker build --check .` resolved `ruby:3.2.8-slim` successfully; it also reported two pre-existing `FromAsCasing` warnings unrelated to this change.
