### PR TITLE
Fix mobile questionnaire risk color compatibility

### DIFF
--- a/app/concepts/api/v1/questionnaires/serializers/show.rb
+++ b/app/concepts/api/v1/questionnaires/serializers/show.rb
@@ -46,7 +46,7 @@ module Api
                       weightedPoints: option&.weighted_points,
                       required: option.required,
                       optionType: option.type_option,
-                      statusColor: option.status_color,
+                      statusColor: option.status_color&.upcase,
                       image: get_image_obj.call(option),
                       position: option.position,
                       next: option.next

--- a/spec/concepts/api/v1/questionnaires/serializers/show_spec.rb
+++ b/spec/concepts/api/v1/questionnaires/serializers/show_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Api::V1::Questionnaires::Serializers::Show do
+  subject(:serialized_questionnaire) { described_class.new(questionnaire).serializable_hash }
+
+  let!(:questionnaire_record) do
+    Questionnaire.create!(
+      name: 'Current questionnaire',
+      current_form: true,
+      initial_question: 1,
+      final_question: 1
+    )
+  end
+  let!(:question) do
+    questionnaire_record.questions.create!(
+      question_text_en: 'Question',
+      type_field: 'list',
+      next: 1
+    )
+  end
+  let!(:option) do
+    question.options.create!(
+      name_en: 'Risk option',
+      position: 1,
+      status_color: Constants::RiskColor::GREEN
+    )
+  end
+  let(:questionnaire) do
+    OpenStruct.new(questionnaire_record.attributes).tap do |record|
+      record.questions = [question]
+      record.language = 'en'
+    end
+  end
+
+  it 'serializes risk colors using the uppercase mobile contract' do
+    status_color = serialized_questionnaire.dig(:data, :attributes, :questions, 0, :options, 0, :statusColor)
+
+    expect(status_color).to eq('GREEN')
+    expect(option.reload.status_color).to eq('green')
+  end
+end


### PR DESCRIPTION
## Summary

- serialize questionnaire `statusColor` values in uppercase for released mobile clients
- keep backend database values and risk calculations lowercase
- add regression coverage for the API contract

## Root cause

The risk-color normalization changed option values from `GREEN`/`YELLOW`/`RED` to lowercase. The questionnaire serializer exposed those internal values directly, while mobile v1.12.2 indexes an uppercase-only asset map. That caused `Cannot read property 'color' of undefined` on visit summaries.

## Validation

- `bundle exec rspec spec/concepts/api/v1/questionnaires/serializers/show_spec.rb`
- RuboCop passes for the new regression spec

The default full-suite command is currently blocked by pre-existing test-loader and `UserProfilesRole` errors on `main`, unrelated to this hotfix.
